### PR TITLE
S2GRAPH-24: Add counter config for readonly graph

### DIFF
--- a/s2counter_core/src/main/scala/s2/config/S2CounterConfig.scala
+++ b/s2counter_core/src/main/scala/s2/config/S2CounterConfig.scala
@@ -28,7 +28,7 @@ class S2CounterConfig(config: Config) extends ConfigFunctions(config) {
   lazy val DB_DEFAULT_USER = getOrElse("db.default.user", "graph")
   lazy val DB_DEFAULT_PASSWORD = getOrElse("db.default.password", "graph")
 
-  // REDIS
+  // Redis
   lazy val REDIS_INSTANCES = (for {
     s <- config.getStringList("redis.instances")
   } yield {
@@ -36,8 +36,9 @@ class S2CounterConfig(config: Config) extends ConfigFunctions(config) {
     (sp(0), if (sp.length > 1) sp(1).toInt else 6379)
   }).toList
 
-  // graph
+  // Graph
   lazy val GRAPH_URL = getOrElse("s2graph.url", "http://localhost:9000")
+  lazy val GRAPH_READONLY_URL = getOrElse("s2graph.read-only.url", GRAPH_URL)
 
   // Cache
   lazy val CACHE_TTL_SECONDS = getOrElse("cache.ttl.seconds", 600)

--- a/s2counter_core/src/main/scala/s2/counter/core/v2/ExactStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/ExactStorageGraph.scala
@@ -35,6 +35,7 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
   private val labelPostfix = "_counts"
 
   val s2graphUrl = s2config.GRAPH_URL
+  val s2graphReadOnlyUrl = s2config.GRAPH_READONLY_URL
   val graphOp = new GraphOperation(config)
 
   import ExactStorageGraph._
@@ -169,7 +170,7 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
     val reqJs = Json.parse(reqJsStr)
 //    log.warn(s"query: ${reqJs.toString()}")
 
-    wsClient.url(s"$s2graphUrl/graphs/getEdges").post(reqJs).map { resp =>
+    wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(reqJs).map { resp =>
       resp.status match {
         case HttpStatus.SC_OK =>
           val respJs = resp.json
@@ -229,7 +230,7 @@ case class ExactStorageGraph(config: Config) extends ExactStorage {
         val query = Json.obj("srcVertices" -> Json.arr(src), "steps" -> Json.arr(step))
         //    println(s"query: ${query.toString()}")
 
-        wsClient.url(s"$s2graphUrl/graphs/getEdges").post(query).map { resp =>
+        wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(query).map { resp =>
           resp.status match {
             case HttpStatus.SC_OK =>
               val respJs = resp.json

--- a/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
+++ b/s2counter_core/src/main/scala/s2/counter/core/v2/RankingStorageGraph.scala
@@ -38,6 +38,7 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
   private val labelPostfix = "_topK"
 
   val s2graphUrl = s2config.GRAPH_URL
+  val s2graphReadOnlyUrl = s2config.GRAPH_READONLY_URL
 
   val prepareCache = new CollectionCache[Option[Boolean]](CollectionCacheConfig(10000, 600))
   val graphOp = new GraphOperation(config)
@@ -240,7 +241,7 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
     log.debug(strJs)
 
     val payload = Json.parse(strJs)
-    wsClient.url(s"$s2graphUrl/graphs/getEdges").post(payload).map { resp =>
+    wsClient.url(s"$s2graphReadOnlyUrl/graphs/getEdges").post(payload).map { resp =>
       resp.status match {
         case HttpStatus.SC_OK =>
           (resp.json \ "results").asOpt[List[JsValue]].getOrElse(Nil)
@@ -272,7 +273,7 @@ class RankingStorageGraph(config: Config) extends RankingStorage {
         )
       )
 
-      val future = wsClient.url(s"$s2graphUrl/graphs/checkEdges").post(checkReqJs).map { resp =>
+      val future = wsClient.url(s"$s2graphReadOnlyUrl/graphs/checkEdges").post(checkReqJs).map { resp =>
         resp.status match {
           case HttpStatus.SC_OK =>
             val checkRespJs = resp.json

--- a/s2counter_loader/src/main/scala/s2/config/StreamingConfig.scala
+++ b/s2counter_loader/src/main/scala/s2/config/StreamingConfig.scala
@@ -20,4 +20,5 @@ object StreamingConfig extends ConfigFunctions(S2ConfigFactory.config) {
 
   // graph url
   val GRAPH_URL = getOrElse("s2graph.url", "")
+  val GRAPH_READONLY_URL = getOrElse("s2graph.read-only.url", GRAPH_URL)
 }

--- a/s2counter_loader/src/test/resources/application.conf
+++ b/s2counter_loader/src/test/resources/application.conf
@@ -75,3 +75,4 @@ profile.prefetch.size=100
 
 # s2graph
 s2graph.url = "http://"${host}":9000"
+s2graph.read-only.url = ${s2graph.url}


### PR DESCRIPTION
Modifications:
Add `GRAPH_READONLY_URL` on `s2.config.StreamingConfig`
Add `GRAPH_READONLY_URL` on `s2.config.S2CounterConfig`
change `s2.counter.core.v2.*StorageGraph` to use the value `GRAPH_READONLY_URL`.

Result:
If we set `s2graph.read-only.url` on application.conf for s2counter_loader. We can read data from the read-only server.