### PR TITLE
[S2GRAPH-28] bug fix in '_to' query

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
@@ -506,12 +506,4 @@ class RequestParser(config: Config) extends JSONParser {
     val vertices = toVertices(labelName, direction, ids)
     (labels, direction, ids, ts, vertices)
   }
-
-  def toSingleDeleteParam(json: JsValue) = {
-    val from = (json \ "from").as[Long]
-    val to = (json \ "from").as[Long]
-    val label = (json \ "label").as[String]
-    val ts = (json \ "timestamp").asOpt[Long].getOrElse(System.currentTimeMillis())
-    (from, to, label, ts)
-  }
 }

--- a/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
@@ -506,4 +506,12 @@ class RequestParser(config: Config) extends JSONParser {
     val vertices = toVertices(labelName, direction, ids)
     (labels, direction, ids, ts, vertices)
   }
+
+  def toSingleDeleteParam(json: JsValue) = {
+    val from = (json \ "from").as[Long]
+    val to = (json \ "from").as[Long]
+    val label = (json \ "label").as[String]
+    val ts = (json \ "timestamp").asOpt[Long].getOrElse(System.currentTimeMillis())
+    (from, to, label, ts)
+  }
 }

--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseQueryBuilder.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseQueryBuilder.scala
@@ -220,7 +220,7 @@ class AsynchbaseQueryBuilder(storage: AsynchbaseStorage)(implicit ec: ExecutionC
           parentEdge <- prevStepEdgesOpt.get
         } yield parentEdge
 
-        fetch(queryRequest, prevStepScore, isInnerCall = true, parentEdges)
+        fetch(queryRequest, prevStepScore, isInnerCall = false, parentEdges)
       }
 
     val grouped: Deferred[util.ArrayList[QueryRequestWithResult]] = Deferred.group(defers)

--- a/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/CrudTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/CrudTest.scala
@@ -173,7 +173,7 @@ class CrudTest extends IntegrateCommon {
             TestUtil.toEdge(ts, op, "e", srcId, tgtId, labelName, props)
           })
 
-          TestUtil.insertEdgesSync(bulkEdges: _*)
+          TestUtil.mutateEdgesSync(bulkEdges: _*)
 
           for {
             label <- Label.findByName(labelName)

--- a/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/IntegrateCommon.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/IntegrateCommon.scala
@@ -119,14 +119,14 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
       jsResult
     }
 
-    def insertEdgesSync(bulkEdges: String*) = {
+    def mutateEdgesSync(bulkEdges: String*) = {
       val req = graph.mutateElements(parser.toGraphElements(bulkEdges.mkString("\n")), withWait = true)
       val jsResult = Await.result(req, HttpRequestWaitingTime)
 
       jsResult
     }
 
-    def insertEdgesAsync(bulkEdges: String*) = {
+    def mutateEdgesAsync(bulkEdges: String*) = {
       val req = graph.mutateElements(parser.toGraphElements(bulkEdges.mkString("\n")), withWait = true)
       req
     }

--- a/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/QueryTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/QueryTest.scala
@@ -8,6 +8,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
   import TestUtil._
 
   val insert = "insert"
+  val delete = "delete"
   val e = "e"
   val weight = "weight"
   val is_hidden = "is_hidden"
@@ -245,7 +246,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
     val src = 100
     val tgt = 200
 
-    insertEdgesSync(toEdge(1001, "insert", "e", src, tgt, testLabelName))
+    mutateEdgesSync(toEdge(1001, "insert", "e", src, tgt, testLabelName))
 
     val result = TestUtil.getEdgesSync(queryParents(src))
     val parents = (result \ "results").as[Seq[JsValue]]
@@ -286,7 +287,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
       toEdge(3003, insert, e, src, 3, testLabelName, Json.obj(weight -> 30)),
       toEdge(4004, insert, e, src, 4, testLabelName, Json.obj(weight -> 40))
     )
-    insertEdgesSync(bulkEdges: _*)
+    mutateEdgesSync(bulkEdges: _*)
 
     var result = getEdgesSync(querySingle(src, offset = 0, limit = 2))
     var edges = (result \ "results").as[List[JsValue]]
@@ -350,7 +351,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
       toEdge(4004, insert, e, 2, 1, testLabelName, Json.obj(weight -> 40))
     )
 
-    insertEdgesSync(bulkEdges: _*)
+    mutateEdgesSync(bulkEdges: _*)
 
     // get edges
     val edges = getEdgesSync(queryScore(0, Map("weight" -> 1)))
@@ -365,6 +366,40 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
     edgesTo should be(orderByTo)
     ascOrderByTo should be(Seq(JsNumber(1), JsNumber(2)))
     edgesTo.reverse should be(ascOrderByTo)
+  }
+
+  test("query with '_to' option after delete") {
+    val from = 90210
+    val to = 90211
+    val inserts = Seq(toEdge(1, insert, e, from, to, testLabelName))
+    mutateEdgesSync(inserts: _*)
+
+    val deletes = Seq(toEdge(2, delete, e, from, to, testLabelName))
+    mutateEdgesSync(deletes: _*)
+
+    def queryWithTo = Json.parse(
+      s"""
+        { "srcVertices": [
+          { "serviceName": "$testServiceName",
+            "columnName": "$testColumnName",
+            "id": $from
+           }],
+          "steps": [
+            {
+              "step": [{
+                "label": "$testLabelName",
+                "direction": "out",
+                "offset": 0,
+                "limit": 10,
+                "_to": $to
+                }]
+            }
+          ]
+        }
+      """)
+    val result = getEdgesSync(queryWithTo)
+    (result \ "results").as[List[JsValue]].size should be(0)
+
   }
 
   test("query with sampling") {
@@ -467,7 +502,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
       toEdge(ts, insert, e, 322, 3322, testLabelName)
     )
 
-    insertEdgesSync(bulkEdges: _*)
+    mutateEdgesSync(bulkEdges: _*)
 
     val result1 = getEdgesSync(queryWithSampling(testId, sampleSize))
     (result1 \ "results").as[List[JsValue]].size should be(math.min(sampleSize, bulkEdges.size))
@@ -504,7 +539,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
   override def initTestData(): Unit = {
     super.initTestData()
 
-    insertEdgesSync(
+    mutateEdgesSync(
       toEdge(1000, insert, e, 0, 1, testLabelName, Json.obj(weight -> 40, is_hidden -> true)),
       toEdge(2000, insert, e, 0, 2, testLabelName, Json.obj(weight -> 30, is_hidden -> false)),
       toEdge(3000, insert, e, 2, 0, testLabelName, Json.obj(weight -> 20)),

--- a/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/StrongLabelDeleteTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/StrongLabelDeleteTest.scala
@@ -14,7 +14,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
   import TestUtil._
 
   test("Strong consistency select") {
-    insertEdgesSync(bulkEdges(): _*)
+    mutateEdgesSync(bulkEdges(): _*)
 
     var result = getEdgesSync(query(0))
     (result \ "results").as[List[JsValue]].size should be(2)
@@ -56,7 +56,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
     println(result)
     (result \ "results").as[List[JsValue]].size should be(0)
 
-    insertEdgesSync(bulkEdges(startTs = deletedAt + 1): _*)
+    mutateEdgesSync(bulkEdges(startTs = deletedAt + 1): _*)
 
     result = getEdgesSync(query(20, direction = "in", columnName = testTgtColumnName))
     println(result)
@@ -136,7 +136,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
     val allRequests = Random.shuffle(insertRequests ++ deleteRequests)
     //        val allRequests = insertRequests ++ deleteRequests
     val futures = allRequests.grouped(numOfConcurrentBatch).map { bulkRequests =>
-      insertEdgesAsync(bulkRequests: _*)
+      mutateEdgesAsync(bulkRequests: _*)
     }
 
     Await.result(Future.sequence(futures), Duration(20, TimeUnit.MINUTES))
@@ -175,7 +175,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
     }
     val allRequests = Random.shuffle(insertRequests ++ deleteRequests)
     val futures = allRequests.grouped(numOfConcurrentBatch).map { bulkRequests =>
-      insertEdgesAsync(bulkRequests: _*)
+      mutateEdgesAsync(bulkRequests: _*)
     }
 
     Await.result(Future.sequence(futures), Duration(20, TimeUnit.MINUTES))
@@ -223,7 +223,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
       allRequests.foreach(println(_))
 
       val futures = Random.shuffle(allRequests).grouped(batchSize).map { bulkRequests =>
-        insertEdgesAsync(bulkRequests: _*)
+        mutateEdgesAsync(bulkRequests: _*)
       }
 
       Await.result(Future.sequence(futures), Duration(20, TimeUnit.MINUTES))

--- a/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/WeakLabelDeleteTest.scala
+++ b/s2core/src/test/scala/com/kakao/s2graph/core/Integrate/WeakLabelDeleteTest.scala
@@ -76,7 +76,7 @@ class WeakLabelDeleteTest extends IntegrateCommon with BeforeAndAfterEach {
     println(result)
     (result \ "results").as[List[JsValue]].size should be(0)
 
-    insertEdgesSync(bulkEdges(startTs = deletedAt + 1): _*)
+    mutateEdgesSync(bulkEdges(startTs = deletedAt + 1): _*)
 
     result = getEdgesSync(query(20, "in", testTgtColumnName))
     (result \ "results").as[List[JsValue]].size should be(3)
@@ -90,7 +90,7 @@ class WeakLabelDeleteTest extends IntegrateCommon with BeforeAndAfterEach {
 
   override def initTestData(): Unit = {
     super.initTestData()
-    insertEdgesSync(bulkEdges(): _*)
+    mutateEdgesSync(bulkEdges(): _*)
   }
 
   object WeakLabelDeleteHelper {


### PR DESCRIPTION
- This resolves S2GRAPH-28.
- Renamed ```insertEdgesSync``` to ```mutateEdgesSync``` since deletions are also handled by this function.