### PR TITLE
[S2GRAPH-26] Apply squash optimization on mutateElements and make it default behavior on Storage.

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
@@ -191,6 +191,12 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     }
   }
 
+  def mutateVertices(vertices: Seq[Vertex],
+                     withWait: Boolean = false): Future[Seq[Boolean]] = {
+    val futures = vertices.map { vertex => mutateVertex(vertex, withWait) }
+    Future.sequence(futures)
+  }
+
   def incrementCounts(edges: Seq[Edge]): Future[Seq[(Boolean, Long)]] = {
     val defers: Seq[Deferred[(Boolean, Long)]] = for {
       edge <- edges


### PR DESCRIPTION
+ Change Graph.mutateElements to use mutateEdges and mutateVertices to use squash optimization.