### PR TITLE
[S2GRAPH-36]: Provide Blocking API for Edge/Vertex operations.

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
@@ -347,7 +347,7 @@ class Graph(_config: Config)(implicit ec: ExecutionContext) {
 
   def mutateVertices(vertices: Seq[Vertex], withWait: Boolean = false): Future[Seq[Boolean]] = storage.mutateVertices(vertices, withWait)
 
-  def incrementCounts(edges: Seq[Edge]): Future[Seq[(Boolean, Long)]] = storage.incrementCounts(edges)
+  def incrementCounts(edges: Seq[Edge], withWait: Boolean): Future[Seq[(Boolean, Long)]] = storage.incrementCounts(edges, withWait)
 
   def shutdown(): Unit = {
     storage.flush()

--- a/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
@@ -344,6 +344,13 @@ class RequestParser(config: Config) extends JSONParser {
 
   }
 
+  def toEdgesWithOrg(jsValue: JsValue, operation: String): (List[Edge], List[JsValue]) = {
+    val jsValues = toJsValues(jsValue)
+    val edges = jsValues.map(toEdge(_, operation))
+
+    (edges, jsValues)
+  }
+
   def toEdges(jsValue: JsValue, operation: String): List[Edge] = {
     toJsValues(jsValue).map(toEdge(_, operation))
   }
@@ -498,7 +505,7 @@ class RequestParser(config: Config) extends JSONParser {
 
   def toDeleteParam(json: JsValue) = {
     val labelName = (json \ "label").as[String]
-    val labels = Label.findByName(labelName).map { l => Seq(l) }.getOrElse(Nil)
+    val labels = Label.findByName(labelName).map { l => Seq(l) }.getOrElse(Nil).filterNot(_.isAsync)
     val direction = (json \ "direction").asOpt[String].getOrElse("out")
 
     val ids = (json \ "ids").asOpt[List[JsValue]].getOrElse(Nil)

--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/Storage.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/Storage.scala
@@ -47,13 +47,16 @@ abstract class Storage(val config: Config)(implicit ec: ExecutionContext) {
     Future.sequence(futures)
   }
 
+
   def mutateEdge(edge: Edge, withWait: Boolean): Future[Boolean]
 
-  def mutateEdges(edges: Seq[Edge],
-                  withWait: Boolean = false): Future[Seq[Boolean]] = {
-    val futures = edges.map { edge => mutateEdge(edge, withWait) }
-    Future.sequence(futures)
-  }
+  def mutateEdges(edges: Seq[Edge], withWait: Boolean = false): Future[Seq[Boolean]]
+
+//  def mutateEdges(edges: Seq[Edge],
+//                  withWait: Boolean = false): Future[Seq[Boolean]] = {
+//    val futures = edges.map { edge => mutateEdge(edge, withWait) }
+//    Future.sequence(futures)
+//  }
 
   def mutateVertex(vertex: Vertex, withWait: Boolean): Future[Boolean]
 
@@ -63,9 +66,9 @@ abstract class Storage(val config: Config)(implicit ec: ExecutionContext) {
     Future.sequence(futures)
   }
 
-  def deleteAllAdjacentEdges(srcVertices: List[Vertex], labels: Seq[Label], dir: Int, ts: Long): Future[Boolean]
+  def deleteAllAdjacentEdges(srcVertices: Seq[Vertex], labels: Seq[Label], dir: Int, ts: Long): Future[Boolean]
 
-  def incrementCounts(edges: Seq[Edge]): Future[Seq[(Boolean, Long)]]
+  def incrementCounts(edges: Seq[Edge], withWait: Boolean): Future[Seq[(Boolean, Long)]]
 
   def flush(): Unit
 

--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
@@ -3,6 +3,7 @@ package com.kakao.s2graph.core.storage.hbase
 import java.util
 
 import com.google.common.cache.Cache
+import com.kakao.s2graph.core.ExceptionHandler.{KafkaMessage, Key, Val}
 import com.kakao.s2graph.core.GraphExceptions.FetchTimeoutException
 import com.kakao.s2graph.core._
 import com.kakao.s2graph.core.mysqls.{Label, LabelMeta}
@@ -17,6 +18,7 @@ import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
 import org.apache.hadoop.hbase.regionserver.BloomType
 import org.apache.hadoop.hbase.util.Bytes
 import org.apache.hadoop.hbase.{HBaseConfiguration, HColumnDescriptor, HTableDescriptor, TableName}
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.hbase.async._
 
 import scala.collection.JavaConversions._
@@ -134,50 +136,67 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
 
 
   def mutateEdge(edge: Edge, withWait: Boolean): Future[Boolean] = {
-    //    mutateEdgeWithOp(edge, withWait)
-    val strongConsistency = edge.label.consistencyLevel == "strong"
     val edgeFuture =
-      if (edge.op == GraphUtil.operations("delete") && !strongConsistency) {
-        val zkQuorum = edge.label.hbaseZkAddr
-        val (_, edgeUpdate) = Edge.buildDeleteBulk(None, edge)
-        val mutations =
-          mutationBuilder.indexedEdgeMutations(edgeUpdate) ++
-            mutationBuilder.snapshotEdgeMutations(edgeUpdate) ++
-            mutationBuilder.increments(edgeUpdate)
-        writeAsyncSimple(zkQuorum, mutations, withWait)
+      if (edge.op == GraphUtil.operations("deleteAll")) {
+        deleteAllAdjacentEdges(Seq(edge.srcVertex), Seq(edge.label), edge.labelWithDir.dir, edge.ts)
       } else {
-        mutateEdgesInner(Seq(edge), strongConsistency, withWait)(Edge.buildOperation)
-      }
-    val vertexFuture = writeAsyncSimple(edge.label.hbaseZkAddr,
-      mutationBuilder.buildVertexPutsAsync(edge), withWait)
-    Future.sequence(Seq(edgeFuture, vertexFuture)).map { rets => rets.forall(identity) }
-  }
-
-  override def mutateEdges(edges: Seq[Edge], withWait: Boolean): Future[Seq[Boolean]] = {
-    val edgeGrouped = edges.groupBy { edge => (edge.label, edge.srcVertex.innerId, edge.tgtVertex.innerId) } toSeq
-
-    val ret = edgeGrouped.map { case ((label, srcId, tgtId), edges) =>
-      if (edges.isEmpty) Future.successful(true)
-      else {
-        val head = edges.head
-        val strongConsistency = head.label.consistencyLevel == "strong"
-
-        if (strongConsistency) {
-          val edgeFuture = mutateEdgesInner(edges, strongConsistency, withWait)(Edge.buildOperation)
-          //TODO: decide what we will do on failure on vertex put
-          val vertexFuture = writeAsyncSimple(head.label.hbaseZkAddr,
-            mutationBuilder.buildVertexPutsAsync(head), withWait)
-          Future.sequence(Seq(edgeFuture, vertexFuture)).map { rets => rets.forall(identity) }
+        val strongConsistency = edge.label.consistencyLevel == "strong"
+        if (edge.op == GraphUtil.operations("delete") && !strongConsistency) {
+          val zkQuorum = edge.label.hbaseZkAddr
+          val (_, edgeUpdate) = Edge.buildDeleteBulk(None, edge)
+          val mutations =
+            mutationBuilder.indexedEdgeMutations(edgeUpdate) ++
+              mutationBuilder.snapshotEdgeMutations(edgeUpdate) ++
+              mutationBuilder.increments(edgeUpdate)
+          writeAsyncSimple(zkQuorum, mutations, withWait)
         } else {
-          Future.sequence(edges.map { edge =>
-            mutateEdge(edge, withWait = withWait)
-          }).map { rets =>
-            rets.forall(identity)
-          }
+          mutateEdgesInner(Seq(edge), strongConsistency, withWait)(Edge.buildOperation)
         }
       }
+
+    val vertexFuture = writeAsyncSimple(edge.label.hbaseZkAddr,
+      mutationBuilder.buildVertexPutsAsync(edge), withWait)
+
+    Future.sequence(Seq(edgeFuture, vertexFuture)).map(_.forall(identity))
+  }
+
+  override def mutateEdges(_edges: Seq[Edge], withWait: Boolean): Future[Seq[Boolean]] = {
+    val grouped = _edges.groupBy { edge => (edge.label, edge.srcVertex.innerId, edge.tgtVertex.innerId) } toSeq
+
+    val mutateEdges = grouped.map { case ((_, _, _), edgeGroup) =>
+      val (deleteAllEdges, edges) = edgeGroup.partition(_.op == GraphUtil.operations("deleteAll"))
+
+      // DeleteAll first
+      val deleteAllFutures = deleteAllEdges.map { edge =>
+        deleteAllAdjacentEdges(Seq(edge.srcVertex), Seq(edge.label), edge.labelWithDir.dir, edge.ts)
+      }
+
+      // After deleteAll, process others
+      lazy val mutateEdgeFutures = edges.toList match {
+        case head :: tail =>
+          val strongConsistency = edges.head.label.consistencyLevel == "strong"
+          if (strongConsistency) {
+            val edgeFuture = mutateEdgesInner(edges, strongConsistency, withWait)(Edge.buildOperation)
+
+            //TODO: decide what we will do on failure on vertex put
+            val puts = mutationBuilder.buildVertexPutsAsync(head)
+            val vertexFuture = writeAsyncSimple(head.label.hbaseZkAddr, puts, withWait)
+            Seq(edgeFuture, vertexFuture)
+          } else {
+            edges.map { edge => mutateEdge(edge, withWait = withWait) }
+          }
+        case Nil => Nil
+      }
+
+      val composed = for {
+        deleteRet <- Future.sequence(deleteAllFutures)
+        mutateRet <- Future.sequence(mutateEdgeFutures)
+      } yield deleteRet ++ mutateRet
+
+      composed.map(_.forall(identity))
     }
-    Future.sequence(ret)
+
+    Future.sequence(mutateEdges)
   }
 
   def mutateVertex(vertex: Vertex, withWait: Boolean): Future[Boolean] = {
@@ -191,7 +210,8 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     }
   }
 
-  def incrementCounts(edges: Seq[Edge]): Future[Seq[(Boolean, Long)]] = {
+  def incrementCounts(edges: Seq[Edge], withWait: Boolean): Future[Seq[(Boolean, Long)]] = {
+    val _client = if (withWait) clientWithFlush else client
     val defers: Seq[Deferred[(Boolean, Long)]] = for {
       edge <- edges
     } yield {
@@ -200,12 +220,14 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
       val countVal = countWithTs.innerVal.toString().toLong
       val incr = mutationBuilder.buildIncrementsCountAsync(edgeWithIndex, countVal).head
       val request = incr.asInstanceOf[AtomicIncrementRequest]
-      client.bufferAtomicIncrement(request) withCallback { resultCount: java.lang.Long =>
+      val defer = _client.bufferAtomicIncrement(request) withCallback { resultCount: java.lang.Long =>
         (true, resultCount.longValue())
       } recoverWith { ex =>
         logger.error(s"mutation failed. $request", ex)
         (false, -1L)
       }
+      if (withWait) defer
+      else Deferred.fromResult((true, -1L))
     }
 
     val grouped: Deferred[util.ArrayList[(Boolean, Long)]] = Deferred.groupInOrder(defers)
@@ -306,7 +328,7 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     logger.debug(msg)
   }
 
-  private def buildLockEdge(snapshotEdgeOpt: Option[Edge], edge: Edge) = {
+  private def buildLockEdge(snapshotEdgeOpt: Option[Edge], edge: Edge, kvOpt: Option[KeyValue]) = {
     val currentTs = System.currentTimeMillis()
     val lockTs = snapshotEdgeOpt match {
       case None => Option(currentTs)
@@ -316,7 +338,8 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
           case Some(pendingEdge) => pendingEdge.lockTs
         }
     }
-    val newVersion = snapshotEdgeOpt.map(_.version).getOrElse(edge.ts) + 1
+    val newVersion = kvOpt.map(_.timestamp()).getOrElse(edge.ts) + 1
+    //      snapshotEdgeOpt.map(_.version).getOrElse(edge.ts) + 1
     val pendingEdge = edge.copy(version = newVersion, statusCode = 1, lockTs = lockTs)
     val base = snapshotEdgeOpt match {
       case None =>
@@ -329,7 +352,8 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     base.copy(version = newVersion, statusCode = 1, lockTs = None)
   }
 
-  private def buildReleaseLockEdge(snapshotEdgeOpt: Option[Edge], lockEdge: SnapshotEdge, edgeMutate: EdgeMutate) = {
+  private def buildReleaseLockEdge(snapshotEdgeOpt: Option[Edge], lockEdge: SnapshotEdge,
+                                   edgeMutate: EdgeMutate) = {
     val newVersion = lockEdge.version + 1
     val base = edgeMutate.newSnapshotEdge match {
       case None =>
@@ -474,9 +498,9 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
                                              edgeUpdate: EdgeMutate): Future[Boolean] = {
     val label = edge.label
     def oldBytes = kvOpt.map(_.value()).getOrElse(Array.empty)
-//    def oldBytes = snapshotEdgeOpt.map { e =>
-//      snapshotEdgeSerializer(e.toSnapshotEdge).toKeyValues.head.value
-//    }.getOrElse(Array.empty)
+    //    def oldBytes = snapshotEdgeOpt.map { e =>
+    //      snapshotEdgeSerializer(e.toSnapshotEdge).toKeyValues.head.value
+    //    }.getOrElse(Array.empty)
     def process(lockEdge: SnapshotEdge,
                 releaseLockEdge: SnapshotEdge,
                 _edgeMutate: EdgeMutate,
@@ -493,7 +517,7 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     }
 
 
-    val lockEdge = buildLockEdge(snapshotEdgeOpt, edge)
+    val lockEdge = buildLockEdge(snapshotEdgeOpt, edge, kvOpt)
     val releaseLockEdge = buildReleaseLockEdge(snapshotEdgeOpt, lockEdge, edgeUpdate)
     snapshotEdgeOpt match {
       case None =>
@@ -510,8 +534,13 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
             if (isLockExpired) {
               val oldSnapshotEdge = if (snapshotEdge.ts == pendingEdge.ts) None else Option(snapshotEdge)
               val (_, newEdgeUpdate) = Edge.buildOperation(oldSnapshotEdge, Seq(pendingEdge))
-              val newLockEdge = buildLockEdge(snapshotEdgeOpt, pendingEdge)
-              val newReleaseLockEdge = buildReleaseLockEdge(snapshotEdgeOpt, newLockEdge, newEdgeUpdate)
+              val newLockEdge = buildLockEdge(snapshotEdgeOpt, pendingEdge, kvOpt)
+              val _newReleaseLockEdge = buildReleaseLockEdge(snapshotEdgeOpt, newLockEdge, newEdgeUpdate)
+
+              // set lock ts as current ts
+              val newPendingEdgeOpt = _newReleaseLockEdge.pendingEdgeOpt.map(_.copy(lockTs = Option(System.currentTimeMillis())))
+              val newReleaseLockEdge = _newReleaseLockEdge.copy(pendingEdgeOpt = newPendingEdgeOpt)
+
               process(newLockEdge, newReleaseLockEdge, newEdgeUpdate, statusCode = 0).flatMap { ret =>
                 val log = s"[Success]: Resolving expired pending edge.\n${pendingEdge.toLogString}"
                 throw new PartialFailureException(edge, 0, log)
@@ -621,10 +650,10 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
       "----------------------------------------------").mkString("\n")
   }
 
-  private def deleteAllFetchedEdgesAsyncOld(queryRequestWithResult: QueryRequestWithResult,
+  private def deleteAllFetchedEdgesAsyncOld(queryRequest: QueryRequest,
+                                            queryResult: QueryResult,
                                             requestTs: Long,
                                             retryNum: Int): Future[Boolean] = {
-    val (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
     val queryParam = queryRequest.queryParam
     val zkQuorum = queryParam.label.hbaseZkAddr
     val futures = for {
@@ -669,7 +698,7 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
 
     val futures = for {
       queryRequestWithResult <- queryRequestWithResultLs
-      (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
+      (queryRequest, _) = QueryRequestWithResult.unapply(queryRequestWithResult).get
       deleteQueryResult = buildEdgesToDelete(queryRequestWithResult, requestTs)
       if deleteQueryResult.edgeWithScoreLs.nonEmpty
     } yield {
@@ -681,14 +710,14 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
             * read: snapshotEdge on queryResult = O(N)
             * write: N x (relatedEdges x indices(indexedEdge) + 1(snapshotEdge))
             */
-          mutateEdges(deleteQueryResult.edgeWithScoreLs.map(_.edge), withWait = true).map { rets => rets.forall(identity) }
+          mutateEdges(deleteQueryResult.edgeWithScoreLs.map(_.edge), withWait = true).map(_.forall(identity))
         case _ =>
 
           /**
             * read: x
             * write: N x ((1(snapshotEdge) + 2(1 for incr, 1 for delete) x indices)
             */
-          deleteAllFetchedEdgesAsyncOld(queryRequestWithResult, requestTs, MaxRetryNum)
+          deleteAllFetchedEdgesAsyncOld(queryRequest, deleteQueryResult, requestTs, MaxRetryNum)
       }
     }
     if (futures.isEmpty) {
@@ -715,10 +744,26 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
 
   }
 
-  def deleteAllAdjacentEdges(srcVertices: List[Vertex],
+  def deleteAllAdjacentEdges(srcVertices: Seq[Vertex],
                              labels: Seq[Label],
                              dir: Int,
                              ts: Long): Future[Boolean] = {
+
+    def enqueueLogMessage() = {
+      val kafkaMessages = for {
+        vertice <- srcVertices
+        id = vertice.innerId.toIdString()
+        label <- labels
+      } yield {
+        val tsv = Seq(ts, "deleteAll", "e", id, id, label.label, "{}", GraphUtil.fromOp(dir.toByte)).mkString("\t")
+        val topic = ExceptionHandler.failTopic
+        val kafkaMsg = KafkaMessage(new ProducerRecord[Key, Val](topic, null, tsv))
+        kafkaMsg
+      }
+
+      ExceptionHandler.enqueues(kafkaMessages)
+    }
+
     val requestTs = ts
     val queryParams = for {
       label <- labels
@@ -731,11 +776,19 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     val q = Query(srcVertices, Vector(step))
 
     //    Extensions.retryOnSuccessWithBackoff(MaxRetryNum, Random.nextInt(MaxBackOff) + 1) {
-    Extensions.retryOnSuccess(MaxRetryNum) {
+    val retryFuture = Extensions.retryOnSuccess(MaxRetryNum) {
       fetchAndDeleteAll(q, requestTs)
     } { case (allDeleted, deleteSuccess) =>
       allDeleted && deleteSuccess
     }.map { case (allDeleted, deleteSuccess) => allDeleted && deleteSuccess }
+
+    retryFuture onFailure {
+      case ex =>
+        logger.error(s"[Error]: deleteAllAdjacentEdges failed.")
+        enqueueLogMessage()
+    }
+
+    retryFuture
   }
 
   def flush(): Unit = clients.foreach { client =>
@@ -790,6 +843,7 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
     val conn = ConnectionFactory.createConnection(conf)
     conn.getAdmin
   }
+
   private def enableTable(zkAddr: String, tableName: String) = {
     getAdmin(zkAddr).enableTable(TableName.valueOf(tableName))
   }

--- a/s2rest_play/conf/routes
+++ b/s2rest_play/conf/routes
@@ -23,8 +23,10 @@ POST        /graphs/edges/deleteAll                                       contro
 POST        /graphs/edges/update                                          controllers.EdgeController.updates()
 POST        /graphs/edges/updateWithWait                                  controllers.EdgeController.updatesWithWait()
 POST        /graphs/edges/increment                                       controllers.EdgeController.increments()
+POST        /graphs/edges/incrementWithWait                               controllers.EdgeController.incrementsWithWait()
 POST        /graphs/edges/incrementCount                                  controllers.EdgeController.incrementCounts()
 POST        /graphs/edges/bulk                                            controllers.EdgeController.mutateBulk()
+POST        /graphs/edges/bulkWithWait                                    controllers.EdgeController.mutateBulkWithWait()
 
 ## Vertex
 POST        /graphs/vertices/insert                                       controllers.VertexController.inserts()


### PR DESCRIPTION
This PR contains following changes.

+ add withWait on incrementCounts/mutateEdgesBulk
+ move logics for deleteAll into s2core from rest project.
+ bug fix for ignoring isAsync flag on label for deleteAll.
+ change kafka message for deleteAll.