### PR TITLE
[S2GRAPH-37] Extract LockExpireDuration as configuration.

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/Graph.scala
@@ -36,6 +36,7 @@ object Graph {
     "hbase.rpcs.buffered_flush_interval" -> java.lang.Short.valueOf(100.toShort),
     "hbase.rpc.timeout" -> java.lang.Integer.valueOf(1000),
     "max.retry.number" -> java.lang.Integer.valueOf(100),
+    "lock.expire.time" -> java.lang.Integer.valueOf(1000 * 60 * 10),
     "max.back.off" -> java.lang.Integer.valueOf(100),
     "hbase.fail.prob" -> java.lang.Double.valueOf(-0.1),
     "delete.all.fetch.size" -> java.lang.Integer.valueOf(1000),

--- a/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/storage/hbase/AsynchbaseStorage.scala
@@ -75,7 +75,7 @@ class AsynchbaseStorage(override val config: Config, vertexCache: Cache[Integer,
   val MaxBackOff = config.getInt("max.back.off")
   val DeleteAllFetchSize = config.getInt("delete.all.fetch.size")
   val FailProb = config.getDouble("hbase.fail.prob")
-  val LockExpireDuration = Math.max(MaxRetryNum * MaxBackOff * 2, 10000)
+  val LockExpireDuration = config.getInt("lock.expire.time")
 
   /**
     * Serializer/Deserializer

--- a/s2rest_play/conf/reference.conf
+++ b/s2rest_play/conf/reference.conf
@@ -108,7 +108,7 @@ max.retry.number=100
 max.back.off=50
 delete.all.fetch.size=10000
 hbase.fail.prob=-1.0
-
+lock.expire.time=600000
 # max allowd edges for deleteAll is multiply of above two configuration.
 
 # set global obejct package, TODO: remove global


### PR DESCRIPTION
+ Extract LockExpireDuration as configuration. 
note that default value for lock.expire.time = 600 secs. 
lock.expire.time > 2 * max.retry.number * max.back.off