### PR TITLE
[S2GRAPH-42] Bug on EdgeTransformer with specific cases.

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/QueryParam.scala
@@ -102,7 +102,8 @@ case class EdgeTransformer(queryParam: QueryParam, jsValue: JsValue) {
               nextStepOpt: Option[Step]): Seq[InnerValLike] = {
 
     val tokens = fmt.split(Delimiter)
-    val mergedStr = tokens.zip(values).map { case (prefix, innerVal) => prefix + innerVal.toString }.mkString
+    val _values = values.padTo(tokens.length, InnerVal.withStr("", queryParam.label.schemaVersion))
+    val mergedStr = tokens.zip(_values).map { case (prefix, innerVal) => prefix + innerVal.toString }.mkString
     //    logger.error(s"${tokens.toList}, ${values}, $mergedStr")
     //    println(s"${tokens.toList}, ${values}, $mergedStr")
     nextStepOpt match {


### PR DESCRIPTION
+ add pad to deal with different size on splitted tokens by on place holder and passed values on transform.

ex) [["age_band.slot.$.8", "age_band"]] should give "age_band.slot.${age_band}.8", not losing last ".8".