### PR TITLE
[S2GRAPH-19] When query with duration error.

### DIFF
--- a/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/com/kakao/s2graph/core/rest/RequestParser.scala
@@ -126,6 +126,10 @@ class RequestParser(config: Config) extends JSONParser {
       val minTs = parse[Option[Long]](js, "from").getOrElse(Long.MaxValue)
       val maxTs = parse[Option[Long]](js, "to").getOrElse(Long.MinValue)
 
+      if (minTs > maxTs) {
+        throw new BadQueryException("Duration error. Timestamp of From cannot be larger than To.")
+      }
+
       (minTs, maxTs)
     }
   }


### PR DESCRIPTION
throw BadQueryException when from > to on duration.