### PR TITLE
[S2GRAPH-81]: Separate Serializable's toKeyValues into 3, toRowKey, toQualifier, toValue

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/Storage.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/Storage.scala
@@ -1213,13 +1213,13 @@ abstract class Storage[R](val config: Config)(implicit ec: ExecutionContext) {
 
   /** IndexEdge */
   def buildIncrementsAsync(indexedEdge: IndexEdge, amount: Long = 1L): Seq[SKeyValue] = {
-    val newProps = indexedEdge.props ++ Map(LabelMeta.degreeSeq -> InnerVal.withLong(amount, indexedEdge.schemaVer))
+    val newProps = indexedEdge.props ++ Map(LabelMeta.degreeSeq -> InnerValLikeWithTs.withLong(amount, indexedEdge.ts, indexedEdge.schemaVer))
     val _indexedEdge = indexedEdge.copy(props = newProps)
     indexEdgeSerializer(_indexedEdge).toKeyValues.map(_.copy(operation = SKeyValue.Increment))
   }
 
   def buildIncrementsCountAsync(indexedEdge: IndexEdge, amount: Long = 1L): Seq[SKeyValue] = {
-    val newProps = indexedEdge.props ++ Map(LabelMeta.countSeq -> InnerVal.withLong(amount, indexedEdge.schemaVer))
+    val newProps = indexedEdge.props ++ Map(LabelMeta.countSeq -> InnerValLikeWithTs.withLong(amount, indexedEdge.ts, indexedEdge.schemaVer))
     val _indexedEdge = indexedEdge.copy(props = newProps)
     indexEdgeSerializer(_indexedEdge).toKeyValues.map(_.copy(operation = SKeyValue.Increment))
   }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/StorageSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/StorageSerializable.scala
@@ -56,5 +56,21 @@ object StorageSerializable {
 }
 
 trait StorageSerializable[E] {
-  def toKeyValues: Seq[SKeyValue]
+  val cf = Serializable.edgeCf
+
+  val table: Array[Byte]
+  val ts: Long
+
+  def toRowKey: Array[Byte]
+  def toQualifier: Array[Byte]
+  def toValue: Array[Byte]
+
+  def toKeyValues: Seq[SKeyValue] = {
+    val row = toRowKey
+    val qualifier = toQualifier
+    val value = toValue
+    val kv = SKeyValue(table, row, cf, qualifier, value, ts)
+
+    Seq(kv)
+  }
 }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeDeserializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeDeserializable.scala
@@ -75,84 +75,87 @@ class IndexEdgeDeserializable(bytesToLongFunc: (Array[Byte], Int) => Long = byte
      (Array.empty[(Byte, InnerValLike)], 0)
    }
 
-   override def fromKeyValuesInner[T: CanSKeyValue](queryParam: QueryParam,
-                                                    _kvs: Seq[T],
-                                                    version: String,
-                                                    cacheElementOpt: Option[IndexEdge]): IndexEdge = {
+  override def fromKeyValuesInner[T: CanSKeyValue](queryParam: QueryParam,
+                                                   _kvs: Seq[T],
+                                                   schemaVer: String,
+                                                   cacheElementOpt: Option[IndexEdge]): IndexEdge = {
 
-     assert(_kvs.size == 1)
+    assert(_kvs.size == 1)
 
-     val kvs = _kvs.map { kv => implicitly[CanSKeyValue[T]].toSKeyValue(kv) }
+    val kvs = _kvs.map { kv => implicitly[CanSKeyValue[T]].toSKeyValue(kv) }
 
-     val kv = kvs.head
+    val kv = kvs.head
+    val version = kv.timestamp
+    //    logger.debug(s"[Des]: ${kv.row.toList}, ${kv.qualifier.toList}, ${kv.value.toList}")
+    var pos = 0
+    val (srcVertexId, srcIdLen) = SourceVertexId.fromBytes(kv.row, pos, kv.row.length, schemaVer)
+    pos += srcIdLen
+    val labelWithDir = LabelWithDirection(Bytes.toInt(kv.row, pos, 4))
+    pos += 4
+    val (labelIdxSeq, isInverted) = bytesToLabelIndexSeqWithIsInverted(kv.row, pos)
+    pos += 1
 
-     //    logger.debug(s"[Des]: ${kv.row.toList}, ${kv.qualifier.toList}, ${kv.value.toList}")
-     var pos = 0
-     val (srcVertexId, srcIdLen) = SourceVertexId.fromBytes(kv.row, pos, kv.row.length, version)
-     pos += srcIdLen
-     val labelWithDir = LabelWithDirection(Bytes.toInt(kv.row, pos, 4))
-     pos += 4
-     val (labelIdxSeq, isInverted) = bytesToLabelIndexSeqWithIsInverted(kv.row, pos)
-     pos += 1
+    val op = kv.row(pos)
+    pos += 1
 
-     val op = kv.row(pos)
-     pos += 1
+    if (pos == kv.row.length) {
+      // degree
+      //      val degreeVal = Bytes.toLong(kv.value)
+      val degreeVal = bytesToLongFunc(kv.value, 0)
+      val ts = kv.timestamp
+      val props = Map(LabelMeta.timeStampSeq -> InnerValLikeWithTs.withLong(ts, ts, schemaVer),
+        LabelMeta.degreeSeq -> InnerValLikeWithTs.withLong(degreeVal, ts, schemaVer))
+      val tgtVertexId = VertexId(HBaseType.DEFAULT_COL_ID, InnerVal.withStr("0", schemaVer))
+      IndexEdge(Vertex(srcVertexId, ts), Vertex(tgtVertexId, ts), labelWithDir, op, ts, labelIdxSeq, props)
+    } else {
+      // not degree edge
 
-     if (pos == kv.row.length) {
-       // degree
-       //      val degreeVal = Bytes.toLong(kv.value)
-       val degreeVal = bytesToLongFunc(kv.value, 0)
-       val ts = kv.timestamp
-       val props = Map(LabelMeta.timeStampSeq -> InnerVal.withLong(ts, version),
-         LabelMeta.degreeSeq -> InnerVal.withLong(degreeVal, version))
-       val tgtVertexId = VertexId(HBaseType.DEFAULT_COL_ID, InnerVal.withStr("0", version))
-       IndexEdge(Vertex(srcVertexId, ts), Vertex(tgtVertexId, ts), labelWithDir, op, ts, labelIdxSeq, props)
-     } else {
-       // not degree edge
 
-       val (idxPropsRaw, endAt) = bytesToProps(kv.row, pos, version)
-       pos = endAt
-       val (tgtVertexIdRaw, tgtVertexIdLen) = if (endAt == kv.row.length) {
-         (HBaseType.defaultTgtVertexId, 0)
-       } else {
-         TargetVertexId.fromBytes(kv.row, endAt, kv.row.length, version)
-       }
+      val (idxPropsRaw, endAt) = bytesToProps(kv.row, pos, schemaVer)
+      pos = endAt
+      val (tgtVertexIdRaw, tgtVertexIdLen) = if (endAt == kv.row.length) {
+        (HBaseType.defaultTgtVertexId, 0)
+      } else {
+        TargetVertexId.fromBytes(kv.row, endAt, kv.row.length, schemaVer)
+      }
 
-       val allProps = immutable.Map.newBuilder[Byte, InnerValLike]
-       /** process index props */
-       val index = queryParam.label.indicesMap.getOrElse(labelIdxSeq, throw new RuntimeException(s"invalid index seq: ${queryParam.label.id.get}, ${labelIdxSeq}"))
+      val allProps = immutable.Map.newBuilder[Byte, InnerValLikeWithTs]
+      val index = queryParam.label.indicesMap.getOrElse(labelIdxSeq, throw new RuntimeException(s"invalid index seq: ${queryParam.label.id.get}, ${labelIdxSeq}"))
 
-       for {
-         (seq, (k, v)) <- index.metaSeqs.zip(idxPropsRaw)
-       } {
-         if (k == LabelMeta.degreeSeq) allProps += k -> v
-         else allProps += seq -> v
-       }
-       /** process props */
-       if (op == GraphUtil.operations("incrementCount")) {
-         //        val countVal = Bytes.toLong(kv.value)
-         val countVal = bytesToLongFunc(kv.value, 0)
-         allProps += (LabelMeta.countSeq -> InnerVal.withLong(countVal, version))
-       } else {
-         val (props, endAt) = bytesToKeyValues(kv.value, 0, kv.value.length, version)
-         props.foreach { case (k, v) =>
-           allProps += (k -> v)
-         }
-       }
-       val _mergedProps = allProps.result()
-       val mergedProps =
-         if (_mergedProps.contains(LabelMeta.timeStampSeq)) _mergedProps
-         else _mergedProps + (LabelMeta.timeStampSeq -> InnerVal.withLong(kv.timestamp, version))
+      /** process indexProps */
+      for {
+        (seq, (k, v)) <- index.metaSeqs.zip(idxPropsRaw)
+      } {
+        if (k == LabelMeta.degreeSeq) allProps += k -> InnerValLikeWithTs(v, version)
+        else allProps += seq -> InnerValLikeWithTs(v, version)
+      }
 
-       val tgtVertexId =
-         mergedProps.get(LabelMeta.toSeq) match {
-           case None => tgtVertexIdRaw
-           case Some(vId) => TargetVertexId(HBaseType.DEFAULT_COL_ID, vId)
-         }
+      /** process props */
+      if (op == GraphUtil.operations("incrementCount")) {
+        //        val countVal = Bytes.toLong(kv.value)
+        val countVal = bytesToLongFunc(kv.value, 0)
+        allProps += (LabelMeta.countSeq -> InnerValLikeWithTs.withLong(countVal, version, schemaVer))
+      } else {
+        val (props, endAt) = bytesToKeyValues(kv.value, 0, kv.value.length, schemaVer)
+        props.foreach { case (k, v) =>
+          allProps += (k -> InnerValLikeWithTs(v, version))
+        }
+      }
+      val _mergedProps = allProps.result()
+      val mergedProps =
+        if (_mergedProps.contains(LabelMeta.timeStampSeq)) _mergedProps
+        else _mergedProps + (LabelMeta.timeStampSeq -> InnerValLikeWithTs.withLong(version, version, schemaVer))
 
-       val ts = kv.timestamp
-       IndexEdge(Vertex(srcVertexId, ts), Vertex(tgtVertexId, ts), labelWithDir, op, ts, labelIdxSeq, mergedProps)
+      /** process tgtVertexId */
+      val tgtVertexId =
+        mergedProps.get(LabelMeta.toSeq) match {
+          case None => tgtVertexIdRaw
+          case Some(vId) => TargetVertexId(HBaseType.DEFAULT_COL_ID, vId.innerVal)
+        }
 
-     }
-   }
- }
+
+      IndexEdge(Vertex(srcVertexId, version), Vertex(tgtVertexId, version), labelWithDir, op, version, labelIdxSeq, mergedProps)
+
+    }
+  }
+}

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeSerializable.scala
@@ -59,9 +59,9 @@ class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge
 
      val value =
        if (indexEdge.degreeEdge)
-         Bytes.toBytes(indexEdge.propsWithTs(LabelMeta.degreeSeq).innerVal.toString().toLong)
+         Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
        else if (indexEdge.op == GraphUtil.operations("incrementCount"))
-         Bytes.toBytes(indexEdge.propsWithTs(LabelMeta.countSeq).innerVal.toString().toLong)
+         Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
        else propsToKeyValues(indexEdge.metas.toSeq)
 
      val kv = SKeyValue(table, rowBytes, cf, qualifierBytes, value, indexEdge.version)

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/tall/IndexEdgeSerializable.scala
@@ -29,14 +29,13 @@ import org.apache.s2graph.core.{GraphUtil, IndexEdge}
 class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge] {
    import StorageSerializable._
 
-   val label = indexEdge.label
-   val table = label.hbaseTableName.getBytes()
-   val cf = Serializable.edgeCf
+   override val ts = indexEdge.version
+   override val table = indexEdge.label.hbaseTableName.getBytes()
 
-   val idxPropsMap = indexEdge.orders.toMap
-   val idxPropsBytes = propsToBytes(indexEdge.orders)
+   def idxPropsMap = indexEdge.orders.toMap
+   def idxPropsBytes = propsToBytes(indexEdge.orders)
 
-   override def toKeyValues: Seq[SKeyValue] = {
+   override def toRowKey: Array[Byte] = {
      val srcIdBytes = VertexId.toSourceVertexId(indexEdge.srcVertex.id).bytes
      val labelWithDirBytes = indexEdge.labelWithDir.bytes
      val labelIndexSeqWithIsInvertedBytes = labelOrderSeqWithIsInverted(indexEdge.labelIndexSeq, isInverted = false)
@@ -53,20 +52,16 @@ class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge
          }
 
      /** TODO search usage of op byte. if there is no, then remove opByte */
-     val rowBytes = Bytes.add(row, Array.fill(1)(GraphUtil.defaultOpByte), qualifier)
-     //    val qualifierBytes = Array.fill(1)(indexEdge.op)
-     val qualifierBytes = Array.empty[Byte]
-
-     val value =
-       if (indexEdge.degreeEdge)
-         Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
-       else if (indexEdge.op == GraphUtil.operations("incrementCount"))
-         Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
-       else propsToKeyValues(indexEdge.metas.toSeq)
-
-     val kv = SKeyValue(table, rowBytes, cf, qualifierBytes, value, indexEdge.version)
-
-     //        logger.debug(s"[Ser]: ${kv.row.toList}, ${kv.qualifier.toList}, ${kv.value.toList}")
-     Seq(kv)
+     Bytes.add(row, Array.fill(1)(GraphUtil.defaultOpByte), qualifier)
    }
+
+   override def toQualifier: Array[Byte] = Array.empty[Byte]
+
+   override def toValue: Array[Byte] =
+     if (indexEdge.degreeEdge)
+       Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
+     else if (indexEdge.op == GraphUtil.operations("incrementCount"))
+       Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
+     else propsToKeyValues(indexEdge.metas.toSeq)
+
  }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeDeserializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeDeserializable.scala
@@ -28,111 +28,109 @@ import org.apache.s2graph.core.{GraphUtil, IndexEdge, QueryParam, Vertex}
 import scala.collection.immutable
 
 class IndexEdgeDeserializable(bytesToLongFunc: (Array[Byte], Int) => Long = bytesToLong) extends Deserializable[IndexEdge] {
-   import StorageDeserializable._
 
-   type QualifierRaw = (Array[(Byte, InnerValLike)], VertexId, Byte, Boolean, Int)
-   type ValueRaw = (Array[(Byte, InnerValLike)], Int)
+  import StorageDeserializable._
 
-   private def parseDegreeQualifier(kv: SKeyValue, version: String): QualifierRaw = {
-     //    val degree = Bytes.toLong(kv.value)
-     val degree = bytesToLongFunc(kv.value, 0)
-     val idxPropsRaw = Array(LabelMeta.degreeSeq -> InnerVal.withLong(degree, version))
-     val tgtVertexIdRaw = VertexId(HBaseType.DEFAULT_COL_ID, InnerVal.withStr("0", version))
-     (idxPropsRaw, tgtVertexIdRaw, GraphUtil.operations("insert"), false, 0)
-   }
+  type QualifierRaw = (Array[(Byte, InnerValLike)], VertexId, Byte, Boolean, Int)
+  type ValueRaw = (Array[(Byte, InnerValLike)], Int)
 
-   private def parseQualifier(kv: SKeyValue, version: String): QualifierRaw = {
-     var qualifierLen = 0
-     var pos = 0
-     val (idxPropsRaw, idxPropsLen, tgtVertexIdRaw, tgtVertexIdLen) = {
-       val (props, endAt) = bytesToProps(kv.qualifier, pos, version)
-       pos = endAt
-       qualifierLen += endAt
-       val (tgtVertexId, tgtVertexIdLen) = if (endAt == kv.qualifier.length) {
-         (HBaseType.defaultTgtVertexId, 0)
-       } else {
-         TargetVertexId.fromBytes(kv.qualifier, endAt, kv.qualifier.length, version)
-       }
-       qualifierLen += tgtVertexIdLen
-       (props, endAt, tgtVertexId, tgtVertexIdLen)
-     }
-     val (op, opLen) =
-       if (kv.qualifier.length == qualifierLen) (GraphUtil.defaultOpByte, 0)
-       else (kv.qualifier(qualifierLen), 1)
+  private def parseDegreeQualifier(kv: SKeyValue, version: String): QualifierRaw = {
+    //    val degree = Bytes.toLong(kv.value)
+    val degree = bytesToLongFunc(kv.value, 0)
+    val idxPropsRaw = Array(LabelMeta.degreeSeq -> InnerVal.withLong(degree, version))
+    val tgtVertexIdRaw = VertexId(HBaseType.DEFAULT_COL_ID, InnerVal.withStr("0", version))
+    (idxPropsRaw, tgtVertexIdRaw, GraphUtil.operations("insert"), false, 0)
+  }
 
-     qualifierLen += opLen
+  private def parseQualifier(kv: SKeyValue, version: String): QualifierRaw = {
+    var qualifierLen = 0
+    var pos = 0
+    val (idxPropsRaw, idxPropsLen, tgtVertexIdRaw, tgtVertexIdLen) = {
+      val (props, endAt) = bytesToProps(kv.qualifier, pos, version)
+      pos = endAt
+      qualifierLen += endAt
+      val (tgtVertexId, tgtVertexIdLen) = if (endAt == kv.qualifier.length) {
+        (HBaseType.defaultTgtVertexId, 0)
+      } else {
+        TargetVertexId.fromBytes(kv.qualifier, endAt, kv.qualifier.length, version)
+      }
+      qualifierLen += tgtVertexIdLen
+      (props, endAt, tgtVertexId, tgtVertexIdLen)
+    }
+    val (op, opLen) =
+      if (kv.qualifier.length == qualifierLen) (GraphUtil.defaultOpByte, 0)
+      else (kv.qualifier(qualifierLen), 1)
 
-     (idxPropsRaw, tgtVertexIdRaw, op, tgtVertexIdLen != 0, qualifierLen)
-   }
+    qualifierLen += opLen
 
-   private def parseValue(kv: SKeyValue, version: String): ValueRaw = {
-     val (props, endAt) = bytesToKeyValues(kv.value, 0, kv.value.length, version)
-     (props, endAt)
-   }
+    (idxPropsRaw, tgtVertexIdRaw, op, tgtVertexIdLen != 0, qualifierLen)
+  }
 
-   private def parseDegreeValue(kv: SKeyValue, version: String): ValueRaw = {
-     (Array.empty[(Byte, InnerValLike)], 0)
-   }
+  private def parseValue(kv: SKeyValue, version: String): ValueRaw = {
+    val (props, endAt) = bytesToKeyValues(kv.value, 0, kv.value.length, version)
+    (props, endAt)
+  }
 
-   override def fromKeyValuesInner[T: CanSKeyValue](queryParam: QueryParam,
-                                                    _kvs: Seq[T],
-                                                    version: String,
-                                                    cacheElementOpt: Option[IndexEdge]): IndexEdge = {
-     assert(_kvs.size == 1)
+  private def parseDegreeValue(kv: SKeyValue, version: String): ValueRaw = {
+    (Array.empty[(Byte, InnerValLike)], 0)
+  }
 
-     val kvs = _kvs.map { kv => implicitly[CanSKeyValue[T]].toSKeyValue(kv) }
+  override def fromKeyValuesInner[T: CanSKeyValue](queryParam: QueryParam,
+                                                   _kvs: Seq[T],
+                                                   schemaVer: String,
+                                                   cacheElementOpt: Option[IndexEdge]): IndexEdge = {
+    assert(_kvs.size == 1)
 
-     val kv = kvs.head
-     val (srcVertexId, labelWithDir, labelIdxSeq, _, _) = cacheElementOpt.map { e =>
-       (e.srcVertex.id, e.labelWithDir, e.labelIndexSeq, false, 0)
-     }.getOrElse(parseRow(kv, version))
+    val kvs = _kvs.map { kv => implicitly[CanSKeyValue[T]].toSKeyValue(kv) }
 
-     val (idxPropsRaw, tgtVertexIdRaw, op, tgtVertexIdInQualifier, _) =
-       if (kv.qualifier.isEmpty) parseDegreeQualifier(kv, version)
-       else parseQualifier(kv, version)
+    val kv = kvs.head
+    val version = kv.timestamp
 
-     val allProps = immutable.Map.newBuilder[Byte, InnerValLike]
+    val (srcVertexId, labelWithDir, labelIdxSeq, _, _) = cacheElementOpt.map { e =>
+      (e.srcVertex.id, e.labelWithDir, e.labelIndexSeq, false, 0)
+    }.getOrElse(parseRow(kv, schemaVer))
 
-     /** process index props */
-     val index = queryParam.label.indicesMap.getOrElse(labelIdxSeq, throw new RuntimeException(s"invalid index seq: ${queryParam.label.id.get}, ${labelIdxSeq}"))
-     for {
-       (seq, (k, v)) <- index.metaSeqs.zip(idxPropsRaw)
-     } {
-       if (k == LabelMeta.degreeSeq) allProps += k -> v
-       else allProps += seq -> v
-     }
+    val (idxPropsRaw, tgtVertexIdRaw, op, tgtVertexIdInQualifier, _) =
+      if (kv.qualifier.isEmpty) parseDegreeQualifier(kv, schemaVer)
+      else parseQualifier(kv, schemaVer)
 
-     /** process props */
-     if (op == GraphUtil.operations("incrementCount")) {
-       //      val countVal = Bytes.toLong(kv.value)
-       val countVal = bytesToLongFunc(kv.value, 0)
-       allProps += (LabelMeta.countSeq -> InnerVal.withLong(countVal, version))
-     } else if (kv.qualifier.isEmpty) {
-       val countVal = bytesToLongFunc(kv.value, 0)
-       allProps += (LabelMeta.degreeSeq -> InnerVal.withLong(countVal, version))
-     } else {
-       val (props, endAt) = bytesToKeyValues(kv.value, 0, kv.value.length, version)
-       props.foreach { case (k, v) =>
-         allProps += (k -> v)
-       }
-     }
+    val allProps = immutable.Map.newBuilder[Byte, InnerValLikeWithTs]
+    val index = queryParam.label.indicesMap.getOrElse(labelIdxSeq, throw new RuntimeException(s"invalid index seq: ${queryParam.label.id.get}, ${labelIdxSeq}"))
 
-     val _mergedProps = allProps.result()
-     val mergedProps =
-       if (_mergedProps.contains(LabelMeta.timeStampSeq)) _mergedProps
-       else _mergedProps + (LabelMeta.timeStampSeq -> InnerVal.withLong(kv.timestamp, version))
+    /** process indexProps */
+    for {
+      (seq, (k, v)) <- index.metaSeqs.zip(idxPropsRaw)
+    } {
+      if (k == LabelMeta.degreeSeq) allProps += k -> InnerValLikeWithTs(v, version)
+      else allProps += seq -> InnerValLikeWithTs(v, version)
+    }
 
-     val tgtVertexId = if (tgtVertexIdInQualifier) {
-       mergedProps.get(LabelMeta.toSeq) match {
-         case None => tgtVertexIdRaw
-         case Some(vId) => TargetVertexId(HBaseType.DEFAULT_COL_ID, vId)
-       }
-     } else tgtVertexIdRaw
-     //    logger.error(s"$mergedProps")
-     //    val ts = mergedProps(LabelMeta.timeStampSeq).toString().toLong
+    /** process props */
+    if (op == GraphUtil.operations("incrementCount")) {
+      //      val countVal = Bytes.toLong(kv.value)
+      val countVal = bytesToLongFunc(kv.value, 0)
+      allProps += (LabelMeta.countSeq -> InnerValLikeWithTs.withLong(countVal, version, schemaVer))
+    } else if (kv.qualifier.isEmpty) {
+      val countVal = bytesToLongFunc(kv.value, 0)
+      allProps += (LabelMeta.degreeSeq -> InnerValLikeWithTs.withLong(countVal, version, schemaVer))
+    } else {
+      val (props, _) = bytesToKeyValues(kv.value, 0, kv.value.length, schemaVer)
+      props.foreach { case (k, v) => allProps += (k -> InnerValLikeWithTs(v, version)) }
+    }
 
-     val ts = kv.timestamp
-     IndexEdge(Vertex(srcVertexId, ts), Vertex(tgtVertexId, ts), labelWithDir, op, ts, labelIdxSeq, mergedProps)
+    val _mergedProps = allProps.result()
+    val mergedProps =
+      if (_mergedProps.contains(LabelMeta.timeStampSeq)) _mergedProps
+      else _mergedProps + (LabelMeta.timeStampSeq -> InnerValLikeWithTs.withLong(version, version, schemaVer))
 
-   }
- }
+    /** process tgtVertexId */
+    val tgtVertexId =
+      mergedProps.get(LabelMeta.toSeq) match {
+        case None => tgtVertexIdRaw
+        case Some(vId) => TargetVertexId(HBaseType.DEFAULT_COL_ID, vId.innerVal)
+      }
+
+    IndexEdge(Vertex(srcVertexId, version), Vertex(tgtVertexId, version), labelWithDir, op, version, labelIdxSeq, mergedProps)
+
+  }
+}

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
@@ -28,44 +28,40 @@ import org.apache.s2graph.core.{GraphUtil, IndexEdge}
 class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge] {
    import StorageSerializable._
 
-   val label = indexEdge.label
-   val table = label.hbaseTableName.getBytes()
-   val cf = Serializable.edgeCf
+   override val ts = indexEdge.version
+   override val table = indexEdge.label.hbaseTableName.getBytes()
 
-   val idxPropsMap = indexEdge.orders.toMap
-   val idxPropsBytes = propsToBytes(indexEdge.orders)
+   def idxPropsMap = indexEdge.orders.toMap
+   def idxPropsBytes = propsToBytes(indexEdge.orders)
 
-   override def toKeyValues: Seq[SKeyValue] = {
+   override def toRowKey: Array[Byte] = {
      val srcIdBytes = VertexId.toSourceVertexId(indexEdge.srcVertex.id).bytes
      val labelWithDirBytes = indexEdge.labelWithDir.bytes
      val labelIndexSeqWithIsInvertedBytes = labelOrderSeqWithIsInverted(indexEdge.labelIndexSeq, isInverted = false)
 
-     val row = Bytes.add(srcIdBytes, labelWithDirBytes, labelIndexSeqWithIsInvertedBytes)
-     //    logger.error(s"${row.toList}\n${srcIdBytes.toList}\n${labelWithDirBytes.toList}\n${labelIndexSeqWithIsInvertedBytes.toList}")
+     Bytes.add(srcIdBytes, labelWithDirBytes, labelIndexSeqWithIsInvertedBytes)
+   }
+
+   override def toQualifier: Array[Byte] = {
      val tgtIdBytes = VertexId.toTargetVertexId(indexEdge.tgtVertex.id).bytes
-     val qualifier =
-       if (indexEdge.degreeEdge) Array.empty[Byte]
-       else {
-         if (indexEdge.op == GraphUtil.operations("incrementCount")) {
-           Bytes.add(idxPropsBytes, tgtIdBytes, Array.fill(1)(indexEdge.op))
-         } else {
-           idxPropsMap.get(LabelMeta.toSeq) match {
-             case None => Bytes.add(idxPropsBytes, tgtIdBytes)
-             case Some(vId) => idxPropsBytes
-           }
+     if (indexEdge.degreeEdge) Array.empty[Byte]
+     else {
+       if (indexEdge.op == GraphUtil.operations("incrementCount")) {
+         Bytes.add(idxPropsBytes, tgtIdBytes, Array.fill(1)(indexEdge.op))
+       } else {
+         idxPropsMap.get(LabelMeta.toSeq) match {
+           case None => Bytes.add(idxPropsBytes, tgtIdBytes)
+           case Some(vId) => idxPropsBytes
          }
        }
-
-
-     val value =
-       if (indexEdge.degreeEdge)
-         Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
-       else if (indexEdge.op == GraphUtil.operations("incrementCount"))
-         Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
-       else propsToKeyValues(indexEdge.metas.toSeq)
-
-     val kv = SKeyValue(table, row, cf, qualifier, value, indexEdge.version)
-
-     Seq(kv)
+     }
    }
+
+  override def toValue: Array[Byte] =
+    if (indexEdge.degreeEdge)
+      Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
+    else if (indexEdge.op == GraphUtil.operations("incrementCount"))
+      Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
+    else propsToKeyValues(indexEdge.metas.toSeq)
+
  }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
@@ -59,9 +59,9 @@ class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge
 
      val value =
        if (indexEdge.degreeEdge)
-         Bytes.toBytes(indexEdge.propsWithTs(LabelMeta.degreeSeq).innerVal.toString().toLong)
+         Bytes.toBytes(indexEdge.props(LabelMeta.degreeSeq).innerVal.toString().toLong)
        else if (indexEdge.op == GraphUtil.operations("incrementCount"))
-         Bytes.toBytes(indexEdge.propsWithTs(LabelMeta.countSeq).innerVal.toString().toLong)
+         Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
        else propsToKeyValues(indexEdge.metas.toSeq)
 
      val kv = SKeyValue(table, row, cf, qualifier, value, indexEdge.version)

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/snapshotedge/tall/SnapshotEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/snapshotedge/tall/SnapshotEdgeSerializable.scala
@@ -29,9 +29,8 @@ import org.apache.s2graph.core.types.SourceAndTargetVertexIdPair
 class SnapshotEdgeSerializable(snapshotEdge: SnapshotEdge) extends Serializable[SnapshotEdge] {
   import StorageSerializable._
 
-  val label = snapshotEdge.label
-  val table = label.hbaseTableName.getBytes()
-  val cf = Serializable.edgeCf
+  override val ts = snapshotEdge.version
+  override val table = snapshotEdge.label.hbaseTableName.getBytes()
 
   def statusCodeWithOp(statusCode: Byte, op: Byte): Array[Byte] = {
     val byte = (((statusCode << 4) | op).toByte)
@@ -40,16 +39,18 @@ class SnapshotEdgeSerializable(snapshotEdge: SnapshotEdge) extends Serializable[
   def valueBytes() = Bytes.add(statusCodeWithOp(snapshotEdge.statusCode, snapshotEdge.op),
     propsToKeyValuesWithTs(snapshotEdge.props.toList))
 
-  override def toKeyValues: Seq[SKeyValue] = {
+  override def toRowKey: Array[Byte] = {
     val srcIdAndTgtIdBytes = SourceAndTargetVertexIdPair(snapshotEdge.srcVertex.innerId, snapshotEdge.tgtVertex.innerId).bytes
     val labelWithDirBytes = snapshotEdge.labelWithDir.bytes
     val labelIndexSeqWithIsInvertedBytes = labelOrderSeqWithIsInverted(LabelIndex.DefaultSeq, isInverted = true)
 
-    val row = Bytes.add(srcIdAndTgtIdBytes, labelWithDirBytes, labelIndexSeqWithIsInvertedBytes)
+    Bytes.add(srcIdAndTgtIdBytes, labelWithDirBytes, labelIndexSeqWithIsInvertedBytes)
+  }
 
-    val qualifier = Array.empty[Byte]
+  override def toQualifier: Array[Byte] = Array.empty[Byte]
 
-    val value = snapshotEdge.pendingEdgeOpt match {
+  override def toValue: Array[Byte] =
+    snapshotEdge.pendingEdgeOpt match {
       case None => valueBytes()
       case Some(pendingEdge) =>
         val opBytes = statusCodeWithOp(pendingEdge.statusCode, pendingEdge.op)
@@ -60,7 +61,4 @@ class SnapshotEdgeSerializable(snapshotEdge: SnapshotEdge) extends Serializable[
         Bytes.add(Bytes.add(valueBytes(), opBytes, versionBytes), Bytes.add(propsBytes, lockBytes))
     }
 
-    val kv = SKeyValue(table, row, cf, qualifier, value, snapshotEdge.version)
-    Seq(kv)
-  }
 }

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/vertex/VertexSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/vertex/VertexSerializable.scala
@@ -25,10 +25,18 @@ import org.apache.s2graph.core.storage.{SKeyValue, Serializable}
 
 case class VertexSerializable(vertex: Vertex) extends Serializable[Vertex] {
 
-  val cf = Serializable.vertexCf
+  override val table = vertex.hbaseTableName.getBytes
+  override val ts = vertex.ts
+  override val cf = Serializable.vertexCf
 
+  override def toRowKey: Array[Byte] = vertex.id.bytes
+
+  override def toQualifier: Array[Byte] = Array.empty[Byte]
+  override def toValue: Array[Byte] = Array.empty[Byte]
+
+  /** vertex override toKeyValues since vertex expect to produce multiple sKeyValues */
   override def toKeyValues: Seq[SKeyValue] = {
-    val row = vertex.id.bytes
+    val row = toRowKey
     val base = for ((k, v) <- vertex.props ++ vertex.defaultProps) yield Bytes.toBytes(k) -> v.bytes
     val belongsTo = vertex.belongLabelIds.map { labelId => Bytes.toBytes(Vertex.toPropKey(labelId)) -> Array.empty[Byte] }
     (base ++ belongsTo).map { case (qualifier, value) =>

--- a/s2core/src/main/scala/org/apache/s2graph/core/types/InnerValLike.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/types/InnerValLike.scala
@@ -248,6 +248,10 @@ object InnerValLikeWithTs extends HBaseDeserializable {
     InnerValLikeWithTs(InnerVal.withLong(l, version), ts)
   }
 
+  def withDouble(d: Double, ts: Long, version: String): InnerValLikeWithTs = {
+    InnerValLikeWithTs(InnerVal.withDouble(d, version), ts)
+  }
+
   def withStr(s: String, ts: Long, version: String): InnerValLikeWithTs = {
     InnerValLikeWithTs(InnerVal.withStr(s, version), ts)
   }

--- a/s2core/src/test/scala/org/apache/s2graph/core/storage/hbase/IndexEdgeTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/storage/hbase/IndexEdgeTest.scala
@@ -35,7 +35,7 @@ class IndexEdgeTest extends FunSuite with Matchers with TestCommonWithModels {
    * @param to: to VertexId for edge.
    * @param props: expected props of edge.
    */
-  def check(l: Label, ts: Long, to: InnerValLike, props: Map[Byte, InnerValLike]): Unit = {
+  def check(l: Label, ts: Long, to: InnerValLike, props: Map[Byte, InnerValLikeWithTs]): Unit = {
     val from = InnerVal.withLong(1, l.schemaVersion)
     val vertexId = SourceVertexId(HBaseType.DEFAULT_COL_ID, from)
     val tgtVertexId = TargetVertexId(HBaseType.DEFAULT_COL_ID, to)
@@ -59,9 +59,9 @@ class IndexEdgeTest extends FunSuite with Matchers with TestCommonWithModels {
       l <- Seq(label, labelV2, labelV3, labelV4)
     } {
       val to = InnerVal.withLong(101, l.schemaVersion)
-      val tsInnerVal = InnerVal.withLong(ts, l.schemaVersion)
-      val props = Map(LabelMeta.timeStampSeq -> tsInnerVal,
-        1.toByte -> InnerVal.withDouble(2.1, l.schemaVersion))
+      val tsInnerValWithTs = InnerValLikeWithTs.withLong(ts, ts, l.schemaVersion)
+      val props = Map(LabelMeta.timeStampSeq -> tsInnerValWithTs,
+        1.toByte -> InnerValLikeWithTs.withDouble(2.1, ts, l.schemaVersion))
 
       check(l, ts, to, props)
     }
@@ -73,10 +73,10 @@ class IndexEdgeTest extends FunSuite with Matchers with TestCommonWithModels {
       l <- Seq(label, labelV2, labelV3, labelV4)
     } {
       val to = InnerVal.withStr("0", l.schemaVersion)
-      val tsInnerVal = InnerVal.withLong(ts, l.schemaVersion)
+      val tsInnerValWithTs = InnerValLikeWithTs.withLong(ts, ts, l.schemaVersion)
       val props = Map(
-        LabelMeta.degreeSeq -> InnerVal.withLong(10, l.schemaVersion),
-        LabelMeta.timeStampSeq -> tsInnerVal)
+        LabelMeta.degreeSeq -> InnerValLikeWithTs.withLong(10, ts, l.schemaVersion),
+        LabelMeta.timeStampSeq -> tsInnerValWithTs)
 
       check(l, ts, to, props)
     }
@@ -88,11 +88,11 @@ class IndexEdgeTest extends FunSuite with Matchers with TestCommonWithModels {
       l <- Seq(label, labelV2, labelV3, labelV4)
     } {
       val to = InnerVal.withLong(101, l.schemaVersion)
+      val tsInnerValWithTs = InnerValLikeWithTs.withLong(ts, ts, l.schemaVersion)
+      val props = Map(LabelMeta.timeStampSeq -> tsInnerValWithTs,
+        1.toByte -> InnerValLikeWithTs.withDouble(2.1, ts, l.schemaVersion),
+        LabelMeta.countSeq -> InnerValLikeWithTs.withLong(10, ts, l.schemaVersion))
 
-      val tsInnerVal = InnerVal.withLong(ts, l.schemaVersion)
-      val props = Map(LabelMeta.timeStampSeq -> tsInnerVal,
-        1.toByte -> InnerVal.withDouble(2.1, l.schemaVersion),
-        LabelMeta.countSeq -> InnerVal.withLong(10, l.schemaVersion))
 
       check(l, ts, to, props)
     }


### PR DESCRIPTION
+ split toKeyValues into toRowKey, toQualifier, toValue, so buildRequest only use toRowKey, toQualifier.