### PR TITLE
[S2GRAPH-114] `MethodNotSupportedException` class in s2counter_core project miss license header.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -194,6 +194,8 @@ Release 0.1.0 - unreleased
     S2GRAPH-111: typo fix: getServiceLable -> getServiceLabel
 		(Contributed by Jong Wook Kim<jongwook@nyu.edu>, committed by DOYUNG YOON).
 
+    S2GRAPH-114: `MethodNotSupportedException` class in s2counter_core project miss license header (Committed by DOYUNG YOON).
+    
   TEST
     
     S2GRAPH-21: Change PostProcessBenchmarkSpec not to store and fetch test data from storage. (Committed by DOYUNG YOON).

--- a/s2counter_core/src/main/scala/org/apache/s2graph/counter/MethodNotSupportedException.scala
+++ b/s2counter_core/src/main/scala/org/apache/s2graph/counter/MethodNotSupportedException.scala
@@ -1,3 +1,0 @@
-package org.apache.s2graph.counter
-
-case class MethodNotSupportedException(message: String, cause: Throwable = null) extends Exception(message, cause)


### PR DESCRIPTION
+ remove unnecessary class `MethodNotSupportedException`.