### PR TITLE
[S2GRAPH-115] ready to upload the binary artifacts to Maven Central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ name := "s2graph"
 lazy val commonSettings = Seq(
   organization := "org.apache.s2graph",
   scalaVersion := "2.11.7",
-  version := "0.1.0",
+  version := "0.1.1-SNAPSHOT",
+  isSnapshot := version.value.endsWith("-SNAPSHOT"),
   scalacOptions := Seq("-language:postfixOps", "-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlint:-missing-interpolator"),
   javaOptions ++= collection.JavaConversions.propertiesAsScalaMap(System.getProperties).map { case (key, value) => "-D" + key + "=" + value }.toSeq,
   testOptions in Test += Tests.Argument("-oDF"),
@@ -35,7 +36,7 @@ lazy val commonSettings = Seq(
   resolvers ++= Seq(
     Resolver.mavenLocal
   )
-)
+) ++ Publisher.defaultSettings
 
 Revolver.settings
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@
  */
 
 import ReleaseTransformations._
+import PgpKeys._
 import sbt.complete.Parsers.spaceDelimited
 
 name := "s2graph"
@@ -25,7 +26,6 @@ name := "s2graph"
 lazy val commonSettings = Seq(
   organization := "org.apache.s2graph",
   scalaVersion := "2.11.7",
-  version := "0.1.1-SNAPSHOT",
   isSnapshot := version.value.endsWith("-SNAPSHOT"),
   scalacOptions := Seq("-language:postfixOps", "-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlint:-missing-interpolator"),
   javaOptions ++= collection.JavaConversions.propertiesAsScalaMap(System.getProperties).map { case (key, value) => "-D" + key + "=" + value }.toSeq,
@@ -77,6 +77,16 @@ runRatTask := {
 
 Packager.defaultSettings
 
+publishSigned := {
+  (publishSigned in s2rest_play).value
+  (publishSigned in s2rest_netty).value
+  (publishSigned in s2core).value
+  (publishSigned in spark).value
+  (publishSigned in loader).value
+  (publishSigned in s2counter_core).value
+  (publishSigned in s2counter_loader).value
+}
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,              // : ReleaseStep
   inquireVersions,                        // : ReleaseStep
@@ -89,6 +99,6 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion
 )
 
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releasePublishArtifactsAction := publishSigned.value
 
-mainClass in (Compile) := None
+mainClass in Compile := None

--- a/project/Publisher.scala
+++ b/project/Publisher.scala
@@ -3,7 +3,9 @@ import sbt._
 import scala.xml.XML
 
 object Publisher {
+
   val defaultSettings = Seq(
+    publish := {}, // disable unsigned publishing
     publishMavenStyle := true,
     publishTo := {
       if (isSnapshot.value) {

--- a/project/Publisher.scala
+++ b/project/Publisher.scala
@@ -5,7 +5,9 @@ import scala.xml.XML
 object Publisher {
 
   val defaultSettings = Seq(
-    publish := {}, // disable unsigned publishing
+    publish := {
+      streams.value.log.error("use publishSigned task instead, to produce code-signed artifacts")
+    },
     publishMavenStyle := true,
     publishTo := {
       if (isSnapshot.value) {

--- a/project/Publisher.scala
+++ b/project/Publisher.scala
@@ -1,0 +1,64 @@
+import sbt.Keys._
+import sbt._
+import scala.xml.XML
+
+object Publisher {
+  val defaultSettings = Seq(
+    publishMavenStyle := true,
+    publishTo := {
+      if (isSnapshot.value) {
+        Some("apache" at "https://repository.apache.org/content/repositories/snapshots")
+      } else {
+        Some("apache" at "https://repository.apache.org/content/repositories/releases")
+      }
+    },
+    credentials ++= {
+      val xml = XML.loadFile(new File(System.getProperty("user.home")) / ".m2" / "settings.xml")
+      for (server <- xml \\ "server" if (server \ "id").text == "apache") yield {
+        Credentials("Sonatype Nexus Repository Manager", "repository.apache.org", (server \ "username").text, (server \ "password").text)
+      }
+    },
+    pomIncludeRepository := { _ => false },
+    pomExtra := {
+      <url>https://github.com/apache/incubator-s2graph</url>
+      <licenses>
+        <license>
+          <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+      </licenses>
+      <scm>
+        <connection>scm:git://git.apache.org/incubator-s2graph.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-s2graph.git</developerConnection>
+        <url>github.com/apache/incubator-s2graph</url>
+      </scm>
+      <developers>
+        <developer>
+          <id>s2graph</id>
+          <name>S2Graph Team</name>
+          <url>http://s2graph.incubator.apache.org/</url>
+        </developer>
+      </developers>
+      <mailingLists>
+        <mailingList>
+          <name>Dev Mailing List</name>
+          <post>dev@s2graph.incubator.apache.org</post>
+          <subscribe>dev-subscribe@s2graph.incubator.apache.org</subscribe>
+          <unsubscribe>dev-unsubscribe@s2graph.incubator.apache.org</unsubscribe>
+        </mailingList>
+        <mailingList>
+          <name>User Mailing List</name>
+          <post>users@s2graph.incubator.apache.org</post>
+          <subscribe>users-subscribe@s2graph.incubator.apache.org</subscribe>
+          <unsubscribe>users-unsubscribe@s2graph.incubator.apache.org</unsubscribe>
+        </mailingList>
+        <mailingList>
+          <name>Commits Mailing List</name>
+          <post>commits@s2graph.incubator.apache.org</post>
+          <subscribe>commits-subscribe@s2graph.incubator.apache.org</subscribe>
+          <unsubscribe>commits-unsubscribe@s2graph.incubator.apache.org</unsubscribe>
+        </mailingList>
+      </mailingLists>
+    }
+  )
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1.1-SNAPSHOT"


### PR DESCRIPTION
Now SBT will add the necessary XMLs to the POM being published, to meet the requirements of ASF and Maven Central.

Additionally, the version is now stored in `version.sbt`, to follow the conventions of sbt-release-plugin.

All subprojects are now configured to be published, and if that is not necessary we can configure to publish only a subset of the subprojects.
