### PR TITLE
[S2GRAPH-126] fixes SBT error that occurs if ~/.m2/settings.xml does not exist

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -117,6 +117,9 @@ Release 0.1.0 - unreleased
     
     S2GRAPH-120: Netty version is conflict with play 2.5.9 (Committed by DOYUNG YOON).
 
+    S2GRAPH-126: SBT error when there is no ~/.m2/settings.xml
+                 (Contributed by Jong Wook Kim<jongwook@nyu.edu>, committed by DOYUNG YOON)
+
   TASKS
 
     S2GRAPH-2: Update document and quick start environment to have recent set-up command changes.

--- a/project/Publisher.scala
+++ b/project/Publisher.scala
@@ -1,5 +1,6 @@
 import sbt.Keys._
 import sbt._
+import scala.util.Try
 import scala.xml.XML
 
 object Publisher {
@@ -17,9 +18,10 @@ object Publisher {
       }
     },
     credentials ++= {
-      val xml = XML.loadFile(new File(System.getProperty("user.home")) / ".m2" / "settings.xml")
-      for (server <- xml \\ "server" if (server \ "id").text == "apache") yield {
-        Credentials("Sonatype Nexus Repository Manager", "repository.apache.org", (server \ "username").text, (server \ "password").text)
+      Try(XML.loadFile(new File(System.getProperty("user.home")) / ".m2" / "settings.xml")).toOption.toSeq.flatMap { xml =>
+        for (server <- xml \\ "server" if (server \ "id").text == "apache") yield {
+          Credentials("Sonatype Nexus Repository Manager", "repository.apache.org", (server \ "username").text, (server \ "password").text)
+        }
       }
     },
     pomIncludeRepository := { _ => false },


### PR DESCRIPTION
Now `credentials` will be empty when settings.xml does not exist.