### PR TITLE
[S2GRAPH-121]: Create `Result` class to hold traverse result edges.

### DIFF
--- a/s2core/src/main/resources/org/apache/s2graph/core/mysqls/schema.sql
+++ b/s2core/src/main/resources/org/apache/s2graph/core/mysqls/schema.sql
@@ -96,6 +96,7 @@ CREATE TABLE `labels` (
   `is_async` tinyint(4) NOT NULL default '0',
   `compressionAlgorithm` varchar(64) NOT NULL DEFAULT 'lz4',
   `options` text,
+  `deleted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ux_label` (`label`),
   INDEX `idx_labels_src_column_name` (`src_column_name`),

--- a/s2core/src/main/scala/org/apache/s2graph/core/GraphExceptions.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/GraphExceptions.scala
@@ -31,6 +31,8 @@ object GraphExceptions {
 
   case class LabelAlreadyExistException(msg: String) extends Exception(msg)
 
+  case class LabelNameTooLongException(msg: String) extends Exception(msg)
+
   case class InternalException(msg: String) extends Exception(msg)
 
   case class IllegalDataTypeException(msg: String) extends Exception(msg)

--- a/s2core/src/main/scala/org/apache/s2graph/core/OrderingUtil.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/OrderingUtil.scala
@@ -49,8 +49,15 @@ object OrderingUtil {
         case (xv: Long, yv: Long) => implicitly[Ordering[Long]].compare(xv, yv)
         case (xv: Double, yv: Double) => implicitly[Ordering[Double]].compare(xv, yv)
         case (xv: String, yv: String) => implicitly[Ordering[String]].compare(xv, yv)
+        case (xv: BigDecimal, yv: BigDecimal) => implicitly[Ordering[BigDecimal]].compare(xv, yv)
         case (xv: JsValue, yv: JsValue) => implicitly[Ordering[JsValue]].compare(xv, yv)
         case (xv: InnerValLike, yv: InnerValLike) => implicitly[Ordering[InnerValLike]].compare(xv, yv)
+        case (xv: BigDecimal, yv: Long) => implicitly[Ordering[BigDecimal]].compare(xv, BigDecimal(yv))
+        case (xv: Long, yv: BigDecimal) => implicitly[Ordering[BigDecimal]].compare(BigDecimal(xv), yv)
+        case (xv: BigDecimal, yv: Int) => implicitly[Ordering[BigDecimal]].compare(xv, BigDecimal(yv))
+        case (xv: Int, yv: BigDecimal) => implicitly[Ordering[BigDecimal]].compare(BigDecimal(xv), yv)
+        case (xv: BigDecimal, yv: Double) => implicitly[Ordering[BigDecimal]].compare(xv, BigDecimal(yv))
+        case (xv: Double, yv: BigDecimal) => implicitly[Ordering[BigDecimal]].compare(BigDecimal(xv), yv)
       }
     }
   }

--- a/s2core/src/main/scala/org/apache/s2graph/core/PostProcess.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/PostProcess.scala
@@ -20,11 +20,13 @@
 package org.apache.s2graph.core
 
 import org.apache.s2graph.core.GraphExceptions.BadQueryException
-import org.apache.s2graph.core.mysqls.{ColumnMeta, Label, LabelMeta, ServiceColumn}
+import org.apache.s2graph.core.mysqls._
 import org.apache.s2graph.core.types.{InnerVal, InnerValLike}
-import play.api.libs.json.{Json, _}
 import org.apache.s2graph.core.JSONParser._
-import scala.collection.mutable.ListBuffer
+import play.api.libs.json.{Json, _}
+
+import scala.collection.immutable
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 object PostProcess {
 
@@ -32,6 +34,7 @@ object PostProcess {
   type EDGE_VALUES = Map[String, JsValue]
   type ORDER_BY_VALUES =  (Any, Any, Any, Any)
   type RAW_EDGE = (EDGE_VALUES, Double, ORDER_BY_VALUES)
+  type GROUP_BY_KEY = Map[String, JsValue]
 
   /**
    * Result Entity score field name
@@ -47,523 +50,153 @@ object PostProcess {
   val SCORE_FIELD_NAME = "scoreSum"
   val reservedColumns = Set("cacheRemain", "from", "to", "label", "direction", "_timestamp", "timestamp", "score", "props")
 
-  def groupEdgeResult(queryRequestWithResultLs: Seq[QueryRequestWithResult], exclude: Seq[QueryRequestWithResult]) = {
-    val excludeIds = resultInnerIds(exclude).map(innerId => innerId -> true).toMap
-    //    filterNot {case (edge, score) => edge.props.contains(LabelMeta.degreeSeq)}
-    val groupedEdgesWithRank = (for {
-      queryRequestWithResult <- queryRequestWithResultLs
-      (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      edgeWithScore <- queryResult.edgeWithScoreLs
-      (edge, score) = EdgeWithScore.unapply(edgeWithScore).get
-      if !excludeIds.contains(toHashKey(edge, queryRequest.queryParam, queryRequest.query.filterOutFields))
-    } yield {
-      (queryRequest.queryParam, edge, score)
-    }).groupBy {
-      case (queryParam, edge, rank) if edge.labelWithDir.dir == GraphUtil.directions("in") =>
-        (queryParam.label.srcColumn, queryParam.label.label, queryParam.label.tgtColumn, edge.tgtVertex.innerId, edge.isDegree)
-      case (queryParam, edge, rank) =>
-        (queryParam.label.tgtColumn, queryParam.label.label, queryParam.label.srcColumn, edge.tgtVertex.innerId, edge.isDegree)
-    }
 
-    val ret = for {
-      ((tgtColumn, labelName, srcColumn, target, isDegreeEdge), edgesAndRanks) <- groupedEdgesWithRank if !isDegreeEdge
-      edgesWithRanks = edgesAndRanks.groupBy(x => x._2.srcVertex).map(_._2.head)
-      id <- innerValToJsValue(target, tgtColumn.columnType)
-    } yield {
-      Json.obj("name" -> tgtColumn.columnName, "id" -> id,
-        SCORE_FIELD_NAME -> edgesWithRanks.map(_._3).sum,
-        "label" -> labelName,
-        "aggr" -> Json.obj(
-          "name" -> srcColumn.columnName,
-          "ids" -> edgesWithRanks.flatMap { case (queryParam, edge, rank) =>
-            innerValToJsValue(edge.srcVertex.innerId, srcColumn.columnType)
-          },
-          "edges" -> edgesWithRanks.map { case (queryParam, edge, rank) =>
-            Json.obj("id" -> innerValToJsValue(edge.srcVertex.innerId, srcColumn.columnType),
-              "props" -> propsToJson(edge),
-              "score" -> rank
-            )
-          }
-        )
-      )
-    }
-
-    ret.toList
-  }
-
-  def sortWithFormatted(jsons: Seq[JsObject],
-                        scoreField: String = "scoreSum",
-                        queryRequestWithResultLs: Seq[QueryRequestWithResult],
-                        decrease: Boolean = true): JsObject = {
-    val ordering = if (decrease) -1 else 1
-    val sortedJsons = jsons.sortBy { jsObject => (jsObject \ scoreField).as[Double] * ordering }
-
-    if (queryRequestWithResultLs.isEmpty) Json.obj("size" -> sortedJsons.size, "results" -> sortedJsons)
-    else Json.obj(
-      "size" -> sortedJsons.size,
-      "results" -> sortedJsons,
-      "impressionId" -> queryRequestWithResultLs.head.queryRequest.query.impressionId()
-    )
-  }
-
-  private def toHashKey(edge: Edge, queryParam: QueryParam, fields: Seq[String], delimiter: String = ","): Int = {
-    val ls = for {
-      field <- fields
-    } yield {
-      field match {
-        case "from" | "_from" => edge.srcVertex.innerId.toIdString()
-        case "to" | "_to" => edge.tgtVertex.innerId.toIdString()
-        case "label" => edge.labelWithDir.labelId
-        case "direction" => JsString(GraphUtil.fromDirection(edge.labelWithDir.dir))
-        case "_timestamp" | "timestamp" => edge.ts
-        case _ =>
-          queryParam.label.metaPropsInvMap.get(field) match {
-            case None => throw new RuntimeException(s"unknow column: $field")
-            case Some(labelMeta) => edge.propsWithTs.get(labelMeta.seq) match {
-              case None => labelMeta.defaultValue
-              case Some(propVal) => propVal
-            }
-          }
-      }
-    }
-    val ret = ls.hashCode()
-    ret
-  }
-
-  def resultInnerIds(queryRequestWithResultLs: Seq[QueryRequestWithResult], isSrcVertex: Boolean = false): Seq[Int] = {
-    for {
-      queryRequestWithResult <- queryRequestWithResultLs
-      (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      q = queryRequest.query
-      edgeWithScore <- queryResult.edgeWithScoreLs
-      (edge, score) = EdgeWithScore.unapply(edgeWithScore).get
-    } yield  toHashKey(edge, queryRequest.queryParam, q.filterOutFields)
-  }
-
-  def summarizeWithListExcludeFormatted(queryRequestWithResultLs: Seq[QueryRequestWithResult], exclude: Seq[QueryRequestWithResult]) = {
-    val jsons = groupEdgeResult(queryRequestWithResultLs, exclude)
-    sortWithFormatted(jsons, queryRequestWithResultLs = queryRequestWithResultLs, decrease = true)
-  }
-
-  def summarizeWithList(queryRequestWithResultLs: Seq[QueryRequestWithResult], exclude: Seq[QueryRequestWithResult]) = {
-    val jsons = groupEdgeResult(queryRequestWithResultLs, exclude)
-    sortWithFormatted(jsons, queryRequestWithResultLs = queryRequestWithResultLs)
-  }
-
-  def summarizeWithListFormatted(queryRequestWithResultLs: Seq[QueryRequestWithResult], exclude: Seq[QueryRequestWithResult]) = {
-    val jsons = groupEdgeResult(queryRequestWithResultLs, exclude)
-    sortWithFormatted(jsons, queryRequestWithResultLs = queryRequestWithResultLs)
-  }
-
-  def toSimpleVertexArrJson(queryRequestWithResultLs: Seq[QueryRequestWithResult]): JsValue = {
-    toSimpleVertexArrJson(queryRequestWithResultLs, Seq.empty[QueryRequestWithResult])
-  }
-
-  private def orderBy(queryOption: QueryOption,
-                      rawEdges: ListBuffer[(EDGE_VALUES, Double, ORDER_BY_VALUES)]): ListBuffer[(EDGE_VALUES, Double, ORDER_BY_VALUES)] = {
-    import OrderingUtil._
-
-    if (queryOption.withScore && queryOption.orderByColumns.nonEmpty) {
-      val ascendingLs = queryOption.orderByColumns.map(_._2)
-      rawEdges.sortBy(_._3)(TupleMultiOrdering[Any](ascendingLs))
-    } else {
-      rawEdges
-    }
-  }
-
-  private def getColumnValue(keyWithJs: Map[String, JsValue], score: Double, edge: Edge, column: String): Any = {
-    column match {
-      case "score" => score
-      case "timestamp" | "_timestamp" => edge.ts
-      case _ =>
-        keyWithJs.get(column) match {
-          case None => keyWithJs.get("props").map { js => (js \ column).as[JsValue] }.get
-          case Some(x) => x
+  def s2EdgeParent(graph: Graph,
+                   parentEdges: Seq[EdgeWithScore]): JsValue = {
+    if (parentEdges.isEmpty) JsNull
+    else {
+      val ancestors = for {
+        current <- parentEdges
+        parents = s2EdgeParent(graph, current.edge.parentEdges) if parents != JsNull
+      } yield {
+          val s2Edge = current.edge.originalEdgeOpt.getOrElse(current.edge)
+          s2EdgeToJsValue(s2Edge, current.score, false, parents = parents)
         }
+      Json.toJson(ancestors)
     }
   }
 
-  private def buildReplaceJson(jsValue: JsValue)(mapper: JsValue => JsValue): JsValue = {
-    def traverse(js: JsValue): JsValue = js match {
-      case JsNull => mapper(JsNull)
-      case JsNumber(v) => mapper(js)
-      case JsString(v) => mapper(js)
-      case JsBoolean(v) => mapper(js)
-      case JsArray(elements) => JsArray(elements.map { t => traverse(mapper(t)) })
-      case JsObject(values) => JsObject(values.map { case (k, v) => k -> traverse(mapper(v)) })
-    }
-
-    traverse(jsValue)
-  }
-
-  /** test query with filterOut is not working since it can not diffrentate filterOut */
-  private def buildNextQuery(jsonQuery: JsValue, _cursors: Seq[Seq[String]]): JsValue = {
-    val cursors = _cursors.flatten.iterator
-
-    buildReplaceJson(jsonQuery) {
-      case js@JsObject(fields) =>
-        val isStep = fields.find { case (k, _) => k == "label" } // find label group
-        if (isStep.isEmpty) js
-        else {
-          // TODO: Order not ensured
-          val withCursor = js.fieldSet | Set("cursor" -> JsString(cursors.next))
-          JsObject(withCursor.toSeq)
-        }
-      case js => js
-    }
-  }
-
-  private def buildRawEdges(queryOption: QueryOption,
-                            queryRequestWithResultLs: Seq[QueryRequestWithResult],
-                            excludeIds: Map[Int, Boolean],
-                            scoreWeight: Double = 1.0): (ListBuffer[JsValue], ListBuffer[RAW_EDGE]) = {
-    val degrees = ListBuffer[JsValue]()
-    val rawEdges = ListBuffer[(EDGE_VALUES, Double, ORDER_BY_VALUES)]()
-    val metaPropNamesMap = scala.collection.mutable.Map[String, Int]()
-    for {
-      queryRequestWithResult <- queryRequestWithResultLs
-    } yield {
-      val (queryRequest, _) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      queryRequest.queryParam.label.metaPropNames.foreach { metaPropName =>
-        metaPropNamesMap.put(metaPropName, metaPropNamesMap.getOrElse(metaPropName, 0) + 1)
-      }
-    }
-    val propsExistInAll = metaPropNamesMap.filter(kv => kv._2 == queryRequestWithResultLs.length)
-    val orderByColumns = queryOption.orderByColumns.filter { case (column, _) =>
-      column match {
-        case "from" | "to" | "label" | "score" | "timestamp" | "_timestamp" => true
-        case _ =>
-          propsExistInAll.contains(column)
-//          //TODO??
-//          false
-//          queryParam.label.metaPropNames.contains(column)
-      }
-    }
-
-    /* build result jsons */
-    for {
-      queryRequestWithResult <- queryRequestWithResultLs
-      (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      queryParam = queryRequest.queryParam
-      edgeWithScore <- queryResult.edgeWithScoreLs
-      (edge, score) = EdgeWithScore.unapply(edgeWithScore).get
-      hashKey = toHashKey(edge, queryRequest.queryParam, queryOption.filterOutFields)
-      if !excludeIds.contains(hashKey)
-    } {
-
-      // edge to json
-      val (srcColumn, _) = queryParam.label.srcTgtColumn(edge.labelWithDir.dir)
-      val fromOpt = innerValToJsValue(edge.srcVertex.id.innerId, srcColumn.columnType)
-      if (edge.isDegree && fromOpt.isDefined) {
-        if (queryOption.limitOpt.isEmpty) {
-          degrees += Json.obj(
-            "from" -> fromOpt.get,
-            "label" -> queryRequest.queryParam.label.label,
-            "direction" -> GraphUtil.fromDirection(edge.labelWithDir.dir),
-            LabelMeta.degree.name -> innerValToJsValue(edge.propsWithTs(LabelMeta.degreeSeq).innerVal, InnerVal.LONG)
-          )
-        }
-      } else {
-        val keyWithJs = edgeToJson(edge, score, queryRequest.query, queryRequest.queryParam)
-        val orderByValues: (Any, Any, Any, Any) = orderByColumns.length match {
-          case 0 =>
-            (None, None, None, None)
-          case 1 =>
-            val it = orderByColumns.iterator
-            val v1 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            (v1, None, None, None)
-          case 2 =>
-            val it = orderByColumns.iterator
-            val v1 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v2 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            (v1, v2, None, None)
-          case 3 =>
-            val it = orderByColumns.iterator
-            val v1 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v2 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v3 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            (v1, v2, v3, None)
-          case _ =>
-            val it = orderByColumns.iterator
-            val v1 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v2 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v3 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            val v4 = getColumnValue(keyWithJs, score, edge, it.next()._1)
-            (v1, v2, v3, v4)
-        }
-
-        val currentEdge = (keyWithJs, score * scoreWeight, orderByValues)
-        rawEdges += currentEdge
-      }
-    }
-    (degrees, rawEdges)
-  }
-
-  private def buildResultJsValue(queryOption: QueryOption,
-                                 degrees: ListBuffer[JsValue],
-                                 rawEdges: ListBuffer[RAW_EDGE]): JsValue = {
-    if (queryOption.groupByColumns.isEmpty) {
-      // ordering
-      val filteredEdges = rawEdges.filter(t => t._2 >= queryOption.scoreThreshold)
-
-      val edges = queryOption.limitOpt match {
-        case None => orderBy(queryOption, filteredEdges).map(_._1)
-        case Some(limit) => orderBy(queryOption, filteredEdges).map(_._1).take(limit)
-      }
-      val resultDegrees = if (queryOption.returnDegree) degrees else emptyDegrees
-
+  def s2EdgeToJsValue(s2Edge: Edge,
+                      score: Double,
+                      isDegree: Boolean = false,
+                      parents: JsValue = JsNull): JsValue = {
+    if (isDegree) {
       Json.obj(
-        "size" -> edges.size,
-        "degrees" -> resultDegrees,
-//        "queryNext" -> buildNextQuery(q.jsonQuery, q.cursorStrings()),
-        "results" -> edges
+        "from" -> anyValToJsValue(s2Edge.srcId),
+        "label" -> s2Edge.labelName,
+        LabelMeta.degree.name -> anyValToJsValue(s2Edge.propsWithTs(LabelMeta.degreeSeq).innerVal.value)
       )
     } else {
-      val grouped = rawEdges.groupBy { case (keyWithJs, _, _) =>
-        val props = keyWithJs.get("props")
+      Json.obj("from" -> anyValToJsValue(s2Edge.srcId),
+        "to" -> anyValToJsValue(s2Edge.tgtId),
+        "label" -> s2Edge.labelName,
+        "score" -> score,
+        "props" -> JSONParser.propertiesToJson(s2Edge.properties),
+        "direction" -> s2Edge.direction,
+        "timestamp" -> anyValToJsValue(s2Edge.ts),
+        "parents" -> parents
+      )
+    }
+  }
 
-        for {
-          column <- queryOption.groupByColumns
-          value <- keyWithJs.get(column) match {
-            case None => props.flatMap { js => (js \ column).asOpt[JsValue] }
-            case Some(x) => Some(x)
-          }
-        } yield column -> value
+  def withImpressionId(queryOption: QueryOption,
+                        size: Int,
+                        degrees: Seq[JsValue],
+                        results: Seq[JsValue]): JsValue = {
+    queryOption.impIdOpt match {
+      case None => Json.obj(
+        "size" -> size,
+        "degrees" -> degrees,
+        "results" -> results
+      )
+      case Some(impId) =>
+        Json.obj(
+          "size" -> size,
+          "degrees" -> degrees,
+          "results" -> results,
+          Experiment.ImpressionKey -> impId
+        )
+    }
+  }
+  def s2VertexToJson(s2Vertex: Vertex): Option[JsValue] = {
+    val props = for {
+      (k, v) <- s2Vertex.properties
+      jsVal <- anyValToJsValue(v)
+    } yield k -> jsVal
+
+    for {
+      id <- anyValToJsValue(s2Vertex.innerIdVal)
+    } yield {
+      Json.obj(
+        "serviceName" -> s2Vertex.serviceName,
+        "columnName" -> s2Vertex.columnName,
+        "id" -> id,
+        "props" -> Json.toJson(props),
+        "timestamp" -> s2Vertex.ts
+      )
+    }
+  }
+
+  def verticesToJson(s2Vertices: Seq[Vertex]): JsValue =
+    Json.toJson(s2Vertices.flatMap(s2VertexToJson(_)))
+
+  def withOptionalFields(queryOption: QueryOption,
+                         size: Int,
+                         degrees: Seq[JsValue],
+                         results: Seq[JsValue],
+                         failCount: Int = 0,
+                         cursors: => JsValue,
+                         nextQuery: => Option[JsValue]): JsValue = {
+
+    val kvs = new ArrayBuffer[(String, JsValue)]()
+
+    kvs.append("size" -> JsNumber(size))
+    kvs.append("degrees" -> JsArray(degrees))
+    kvs.append("results" -> JsArray(results))
+
+    if (queryOption.impIdOpt.isDefined) kvs.append(Experiment.ImpressionKey -> JsString(queryOption.impIdOpt.get))
+
+    JsObject(kvs)
+  }
+
+  def toJson(graph: Graph,
+             queryOption: QueryOption,
+             stepResult: StepResult): JsValue = {
+
+
+    val degrees =
+      if (queryOption.returnDegree) stepResult.degreeEdges.map(t => s2EdgeToJsValue(t.s2Edge, t.score, true))
+      else emptyDegrees
+
+    if (queryOption.groupBy.keys.isEmpty) {
+      // no group by specified on query.
+
+      val ls = stepResult.results.map { t =>
+        val parents = if (queryOption.returnTree) s2EdgeParent(graph, t.parentEdges) else JsNull
+        s2EdgeToJsValue(t.s2Edge, t.score, false, parents)
       }
+      withImpressionId(queryOption, ls.size, degrees, ls)
+    } else {
 
-      val groupedEdgesWithScoreSum =
+      val results =
         for {
-          (groupByKeyVals, groupedRawEdges) <- grouped
-          scoreSum = groupedRawEdges.map(x => x._2).sum if scoreSum >= queryOption.scoreThreshold
+          (groupByValues, (scoreSum, edges)) <- stepResult.grouped
         } yield {
-          // ordering
-          val edges = orderBy(queryOption, groupedRawEdges).map(_._1)
+          val groupByKeyValues = queryOption.groupBy.keys.zip(groupByValues).map { case (k, valueOpt) =>
+            k -> valueOpt.flatMap(anyValToJsValue).getOrElse(JsNull)
+          }
+          val groupByValuesJson = Json.toJson(groupByKeyValues.toMap)
 
-          //TODO: refactor this
-          val js = if (queryOption.returnAgg)
+          if (!queryOption.returnAgg) {
             Json.obj(
-              "groupBy" -> Json.toJson(groupByKeyVals.toMap),
-              "scoreSum" -> scoreSum,
-              "agg" -> edges
-            )
-          else
-            Json.obj(
-              "groupBy" -> Json.toJson(groupByKeyVals.toMap),
+              "groupBy" -> groupByValuesJson,
               "scoreSum" -> scoreSum,
               "agg" -> Json.arr()
             )
-          (js, scoreSum)
+          } else {
+            val agg = edges.map { t =>
+              val parents = if (queryOption.returnTree) s2EdgeParent(graph, t.parentEdges) else JsNull
+              s2EdgeToJsValue(t.s2Edge, t.score, false, parents)
+            }
+            val aggJson = Json.toJson(agg)
+            Json.obj(
+              "groupBy" -> groupByValuesJson,
+              "scoreSum" -> scoreSum,
+              "agg" -> aggJson
+            )
+          }
         }
-
-      val groupedSortedJsons = queryOption.limitOpt match {
-        case None =>
-          groupedEdgesWithScoreSum.toList.sortBy { case (jsVal, scoreSum) => scoreSum * -1 }.map(_._1)
-        case Some(limit) =>
-          groupedEdgesWithScoreSum.toList.sortBy { case (jsVal, scoreSum) => scoreSum * -1 }.map(_._1).take(limit)
-      }
-      val resultDegrees = if (queryOption.returnDegree) degrees else emptyDegrees
-      Json.obj(
-        "size" -> groupedSortedJsons.size,
-        "degrees" -> resultDegrees,
-//        "queryNext" -> buildNextQuery(q.jsonQuery, q.cursorStrings()),
-        "results" -> groupedSortedJsons
-      )
+      withImpressionId(queryOption, results.size, degrees, results)
     }
   }
-
-  def toSimpleVertexArrJsonMulti(queryOption: QueryOption,
-                                 resultWithExcludeLs: Seq[(Seq[QueryRequestWithResult], Seq[QueryRequestWithResult])],
-                                 excludes: Seq[QueryRequestWithResult]): JsValue = {
-    val excludeIds = (Seq((Seq.empty, excludes)) ++ resultWithExcludeLs).foldLeft(Map.empty[Int, Boolean]) { case (acc, (result, excludes)) =>
-      acc ++ resultInnerIds(excludes).map(hashKey => hashKey -> true).toMap
-    }
-
-    val (degrees, rawEdges) = (ListBuffer.empty[JsValue], ListBuffer.empty[RAW_EDGE])
-    for {
-      (result, localExclude) <- resultWithExcludeLs
-    } {
-      val newResult = result.map { queryRequestWithResult =>
-        val (queryRequest, _) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-        val newQuery = queryRequest.query.copy(queryOption = queryOption)
-        queryRequestWithResult.copy(queryRequest = queryRequest.copy(query = newQuery))
-      }
-      val (_degrees, _rawEdges) = buildRawEdges(queryOption, newResult, excludeIds)
-      degrees ++= _degrees
-      rawEdges ++= _rawEdges
-    }
-    buildResultJsValue(queryOption, degrees, rawEdges)
-  }
-
-  def toSimpleVertexArrJson(queryOption: QueryOption,
-                            queryRequestWithResultLs: Seq[QueryRequestWithResult],
-                            exclude: Seq[QueryRequestWithResult]): JsValue = {
-    val excludeIds = resultInnerIds(exclude).map(innerId => innerId -> true).toMap
-    val (degrees, rawEdges) = buildRawEdges(queryOption, queryRequestWithResultLs, excludeIds)
-    buildResultJsValue(queryOption, degrees, rawEdges)
-  }
-
-
-  def toSimpleVertexArrJson(queryRequestWithResultLs: Seq[QueryRequestWithResult],
-                            exclude: Seq[QueryRequestWithResult]): JsValue = {
-
-    queryRequestWithResultLs.headOption.map { queryRequestWithResult =>
-      val (queryRequest, _) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      val query = queryRequest.query
-      val queryOption = query.queryOption
-      val excludeIds = resultInnerIds(exclude).map(innerId => innerId -> true).toMap
-      val (degrees, rawEdges) = buildRawEdges(queryOption, queryRequestWithResultLs, excludeIds)
-      buildResultJsValue(queryOption, degrees, rawEdges)
-    } getOrElse emptyResults
-  }
-
-  def verticesToJson(vertices: Iterable[Vertex]) = {
-    Json.toJson(vertices.flatMap { v => vertexToJson(v) })
-  }
-
-  def propsToJson(edge: Edge, q: Query, queryParam: QueryParam): Map[String, JsValue] = {
-    for {
-      (seq, innerValWithTs) <- edge.propsWithTs if LabelMeta.isValidSeq(seq)
-      labelMeta <- queryParam.label.metaPropsMap.get(seq)
-      jsValue <- innerValToJsValue(innerValWithTs.innerVal, labelMeta.dataType)
-    } yield labelMeta.name -> jsValue
-  }
-
-  private def edgeParent(parentEdges: Seq[EdgeWithScore], q: Query, queryParam: QueryParam): JsValue = {
-    if (parentEdges.isEmpty) {
-      JsNull
-    } else {
-      val parents = for {
-        parent <- parentEdges
-        (parentEdge, parentScore) = EdgeWithScore.unapply(parent).get
-        parentQueryParam = QueryParam(parentEdge.labelWithDir)
-        parents = edgeParent(parentEdge.parentEdges, q, parentQueryParam) if parents != JsNull
-      } yield {
-        val originalEdge = parentEdge.originalEdgeOpt.getOrElse(parentEdge)
-        val edgeJson = edgeToJsonInner(originalEdge, parentScore, q, parentQueryParam) + ("parents" -> parents)
-        Json.toJson(edgeJson)
-      }
-
-      Json.toJson(parents)
-    }
-  }
-
-  /** TODO */
-  def edgeToJsonInner(edge: Edge, score: Double, q: Query, queryParam: QueryParam): Map[String, JsValue] = {
-    val (srcColumn, tgtColumn) = queryParam.label.srcTgtColumn(edge.labelWithDir.dir)
-
-    val kvMapOpt = for {
-      from <- innerValToJsValue(edge.srcVertex.id.innerId, srcColumn.columnType)
-      to <- innerValToJsValue(edge.tgtVertex.id.innerId, tgtColumn.columnType)
-    } yield {
-      val targetColumns = if (q.selectColumnsSet.isEmpty) reservedColumns else (reservedColumns & q.selectColumnsSet) + "props"
-      val _propsMap = queryParam.label.metaPropsDefaultMapInner ++ propsToJson(edge, q, queryParam)
-      val propsMap = if (q.selectColumnsSet.nonEmpty) _propsMap.filterKeys(q.selectColumnsSet) else _propsMap
-
-      val kvMap = targetColumns.foldLeft(Map.empty[String, JsValue]) { (map, column) =>
-        val jsValue = column match {
-          case "cacheRemain" => JsNumber(queryParam.cacheTTLInMillis - (System.currentTimeMillis() - queryParam.timestamp))
-          case "from" => from
-          case "to" => to
-          case "label" => JsString(queryParam.label.label)
-          case "direction" => JsString(GraphUtil.fromDirection(edge.labelWithDir.dir))
-          case "_timestamp" | "timestamp" => JsNumber(edge.ts)
-          case "score" => JsNumber(score)
-          case "props" if propsMap.nonEmpty => Json.toJson(propsMap)
-          case _ => JsNull
-        }
-
-        if (jsValue == JsNull) map else map + (column -> jsValue)
-      }
-      kvMap
-    }
-
-    kvMapOpt.getOrElse(Map.empty)
-  }
-
-  def edgeToJson(edge: Edge, score: Double, q: Query, queryParam: QueryParam): Map[String, JsValue] = {
-    val kvs = edgeToJsonInner(edge, score, q, queryParam)
-    if (kvs.nonEmpty && q.returnTree) kvs + ("parents" -> Json.toJson(edgeParent(edge.parentEdges, q, queryParam)))
-    else kvs
-  }
-
-  def vertexToJson(vertex: Vertex): Option[JsObject] = {
-    val serviceColumn = ServiceColumn.findById(vertex.id.colId)
-
-    for {
-      id <- innerValToJsValue(vertex.innerId, serviceColumn.columnType)
-    } yield {
-      Json.obj("serviceName" -> serviceColumn.service.serviceName,
-        "columnName" -> serviceColumn.columnName,
-        "id" -> id, "props" -> propsToJson(vertex),
-        "timestamp" -> vertex.ts,
-        //        "belongsTo" -> vertex.belongLabelIds)
-        "belongsTo" -> vertex.belongLabelIds.flatMap(Label.findByIdOpt(_).map(_.label)))
-    }
-  }
-
-  private def keysToName(seqsToNames: Map[Int, String], props: Map[Int, InnerValLike]) = {
-    for {
-      (seq, value) <- props
-      name <- seqsToNames.get(seq)
-    } yield (name, value)
-  }
-
-  private def propsToJson(vertex: Vertex) = {
-    val serviceColumn = vertex.serviceColumn
-    val props = for {
-      (propKey, innerVal) <- vertex.props
-      columnMeta <- ColumnMeta.findByIdAndSeq(serviceColumn.id.get, propKey.toByte, useCache = true)
-      jsValue <- innerValToJsValue(innerVal, columnMeta.dataType)
-    } yield {
-      (columnMeta.name -> jsValue)
-    }
-    props.toMap
-  }
-
-  def propsToJson(edge: Edge) = {
-    for {
-      (seq, v) <- edge.propsWithTs if LabelMeta.isValidSeq(seq)
-      metaProp <- edge.label.metaPropsMap.get(seq)
-      jsValue <- innerValToJsValue(v.innerVal, metaProp.dataType)
-    } yield {
-      (metaProp.name, jsValue)
-    }
-  }
-
-  def summarizeWithListExclude(queryRequestWithResultLs: Seq[QueryRequestWithResult], exclude: Seq[QueryRequestWithResult]): JsObject = {
-    val excludeIds = resultInnerIds(exclude).map(innerId => innerId -> true).toMap
-
-
-    val groupedEdgesWithRank = (for {
-      queryRequestWithResult <- queryRequestWithResultLs
-      (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-      edgeWithScore <- queryResult.edgeWithScoreLs
-      (edge, score) = EdgeWithScore.unapply(edgeWithScore).get
-      if !excludeIds.contains(toHashKey(edge, queryRequest.queryParam, queryRequest.query.filterOutFields))
-    } yield {
-      (edge, score)
-    }).groupBy { case (edge, score) =>
-      (edge.label.tgtColumn, edge.label.srcColumn, edge.tgtVertex.innerId)
-    }
-
-    val jsons = for {
-      ((tgtColumn, srcColumn, target), edgesAndRanks) <- groupedEdgesWithRank
-      (edges, ranks) = edgesAndRanks.groupBy(x => x._1.srcVertex).map(_._2.head).unzip
-      tgtId <- innerValToJsValue(target, tgtColumn.columnType)
-    } yield {
-      Json.obj(tgtColumn.columnName -> tgtId,
-        s"${srcColumn.columnName}s" ->
-          edges.flatMap(edge => innerValToJsValue(edge.srcVertex.innerId, srcColumn.columnType)), "scoreSum" -> ranks.sum)
-    }
-    val sortedJsons = jsons.toList.sortBy { jsObj => (jsObj \ "scoreSum").as[Double] }.reverse
-    if (queryRequestWithResultLs.isEmpty) {
-      Json.obj("size" -> sortedJsons.size, "results" -> sortedJsons)
-    } else {
-      Json.obj("size" -> sortedJsons.size, "results" -> sortedJsons,
-        "impressionId" -> queryRequestWithResultLs.head.queryRequest.query.impressionId())
-    }
-
-  }
-
-
 }

--- a/s2core/src/main/scala/org/apache/s2graph/core/QueryResult.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/QueryResult.scala
@@ -21,31 +21,42 @@ package org.apache.s2graph.core
 
 import org.apache.s2graph.core.mysqls.LabelMeta
 import org.apache.s2graph.core.types.{InnerVal, InnerValLikeWithTs}
+import org.apache.s2graph.core.utils.logger
 
-import scala.collection.Seq
+import scala.collection.mutable.ListBuffer
+import scala.collection.{Seq, mutable}
 
 object QueryResult {
-  def fromVertices(query: Query): Seq[QueryRequestWithResult] = {
+  def fromVertices(query: Query): StepInnerResult = {
     if (query.steps.isEmpty || query.steps.head.queryParams.isEmpty) {
-      Seq.empty
+      StepInnerResult.Empty
     } else {
       val queryParam = query.steps.head.queryParams.head
       val label = queryParam.label
       val currentTs = System.currentTimeMillis()
       val propsWithTs = Map(LabelMeta.timeStampSeq ->
         InnerValLikeWithTs(InnerVal.withLong(currentTs, label.schemaVersion), currentTs))
-      for {
+      val edgeWithScoreLs = for {
         vertex <- query.vertices
       } yield {
-        val edge = Edge(vertex, vertex, queryParam.labelWithDir, propsWithTs = propsWithTs)
-        val edgeWithScore = EdgeWithScore(edge, Graph.DefaultScore)
-        QueryRequestWithResult(QueryRequest(query, -1, vertex, queryParam),
-          QueryResult(edgeWithScoreLs = Seq(edgeWithScore)))
-      }
+          val edge = Edge(vertex, vertex, queryParam.labelWithDir, propsWithTs = propsWithTs)
+          val edgeWithScore = EdgeWithScore(edge, Graph.DefaultScore)
+          edgeWithScore
+        }
+      StepInnerResult(edgesWithScoreLs = edgeWithScoreLs, Nil, false)
     }
   }
 }
-case class QueryRequestWithResult(queryRequest: QueryRequest, queryResult: QueryResult)
+/** inner traverse */
+object StepInnerResult {
+  val Failure = StepInnerResult(Nil, Nil, true)
+  val Empty = StepInnerResult(Nil, Nil, false)
+}
+case class StepInnerResult(edgesWithScoreLs: Seq[EdgeWithScore],
+                           degreeEdges: Seq[EdgeWithScore],
+                           isFailure: Boolean = false) {
+  val isEmpty = edgesWithScoreLs.isEmpty
+}
 
 case class QueryRequest(query: Query,
                         stepIdx: Int,
@@ -59,3 +70,206 @@ case class QueryResult(edgeWithScoreLs: Seq[EdgeWithScore] = Nil,
                        isFailure: Boolean = false)
 
 case class EdgeWithScore(edge: Edge, score: Double)
+
+
+
+
+
+/** result */
+
+object StepResult {
+
+  type Values = Seq[S2EdgeWithScore]
+  type GroupByKey = Seq[Option[Any]]
+  val EmptyOrderByValues = (None, None, None, None)
+  val Empty = StepResult(Nil, Nil, Nil)
+
+
+  def mergeOrdered(left: StepResult.Values,
+                   right: StepResult.Values,
+                   queryOption: QueryOption): (Double, StepResult.Values) = {
+    val merged = (left ++ right)
+    val scoreSum = merged.foldLeft(0.0) { case (prev, current) => prev + current.score }
+    if (scoreSum < queryOption.scoreThreshold) (0.0, Nil)
+    else {
+      val ordered = orderBy(queryOption, merged)
+      val filtered = ordered.take(queryOption.groupBy.limit)
+      val newScoreSum = filtered.foldLeft(0.0) { case (prev, current) => prev + current.score }
+      (newScoreSum, filtered)
+    }
+  }
+
+  def orderBy(queryOption: QueryOption, notOrdered: Values): Values = {
+    import OrderingUtil._
+
+    if (queryOption.withScore && queryOption.orderByColumns.nonEmpty) {
+      notOrdered.sortBy(_.orderByValues)(TupleMultiOrdering[Any](queryOption.ascendingVals))
+    } else {
+      notOrdered
+    }
+  }
+  def toOrderByValues(s2Edge: Edge,
+                      score: Double,
+                      orderByKeys: Seq[String]): (Any, Any, Any, Any) = {
+    def toValue(propertyKey: String): Any = {
+      propertyKey match {
+        case "score" => score
+        case "timestamp" | "_timestamp" => s2Edge.ts
+        case _ => s2Edge.properties.get(propertyKey)
+      }
+    }
+    if (orderByKeys.isEmpty) (None, None, None, None)
+    else {
+      orderByKeys.length match {
+        case 1 =>
+          (toValue(orderByKeys(0)), None, None, None)
+        case 2 =>
+          (toValue(orderByKeys(0)), toValue(orderByKeys(1)), None, None)
+        case 3 =>
+          (toValue(orderByKeys(0)), toValue(orderByKeys(1)), toValue(orderByKeys(2)), None)
+        case _ =>
+          (toValue(orderByKeys(0)), toValue(orderByKeys(1)), toValue(orderByKeys(2)), toValue(orderByKeys(3)))
+      }
+    }
+  }
+  /**
+   * merge multiple StepResult into one StepResult.
+   * @param queryOption
+   * @param multiStepResults
+   * @return
+   */
+  def merges(queryOption: QueryOption,
+             multiStepResults: Seq[StepResult],
+             weights: Seq[Double] = Nil): StepResult = {
+    val degrees = multiStepResults.flatMap(_.degreeEdges)
+    val ls = new mutable.ListBuffer[S2EdgeWithScore]()
+    val agg= new mutable.HashMap[GroupByKey, ListBuffer[S2EdgeWithScore]]()
+    val sums = new mutable.HashMap[GroupByKey, Double]()
+
+    for {
+      (weight, eachStepResult) <- weights.zip(multiStepResults)
+      (ordered, grouped) = (eachStepResult.results, eachStepResult.grouped)
+    } {
+      ordered.foreach { t =>
+        val newScore = t.score * weight
+        ls += t.copy(score = newScore)
+      }
+
+      // process each query's stepResult's grouped
+      for {
+        (groupByKey, (scoreSum, values)) <- grouped
+      } {
+        val buffer = agg.getOrElseUpdate(groupByKey, ListBuffer.empty[S2EdgeWithScore])
+        var scoreSum = 0.0
+        values.foreach { t =>
+          val newScore = t.score * weight
+          buffer += t.copy(score = newScore)
+          scoreSum += newScore
+        }
+        sums += (groupByKey -> scoreSum)
+      }
+    }
+
+    // process global groupBy
+    if (queryOption.groupBy.keys.nonEmpty) {
+      for {
+        s2EdgeWithScore <- ls
+        groupByKey = s2EdgeWithScore.s2Edge.selectValues(queryOption.groupBy.keys)
+      } {
+        val buffer = agg.getOrElseUpdate(groupByKey, ListBuffer.empty[S2EdgeWithScore])
+        buffer += s2EdgeWithScore
+        val newScore = sums.getOrElse(groupByKey, 0.0) + s2EdgeWithScore.score
+        sums += (groupByKey -> newScore)
+      }
+    }
+
+
+    val ordered = orderBy(queryOption, ls)
+    val grouped = for {
+      (groupByKey, scoreSum) <- sums.toSeq.sortBy(_._2 * -1)
+      aggregated = agg(groupByKey) if aggregated.nonEmpty
+    } yield groupByKey -> (scoreSum, aggregated)
+
+    StepResult(results = ordered, grouped = grouped, degrees)
+  }
+
+  //TODO: Optimize this.
+  def filterOut(graph: Graph,
+                queryOption: QueryOption,
+                baseStepResult: StepResult,
+                filterOutStepInnerResult: StepInnerResult): StepResult = {
+
+    val fields = if (queryOption.filterOutFields.isEmpty) Seq("to") else Seq("to")
+    //    else queryOption.filterOutFields
+    val filterOutSet = filterOutStepInnerResult.edgesWithScoreLs.map { t =>
+      t.edge.selectValues(fields)
+    }.toSet
+
+    val filteredResults = baseStepResult.results.filter { t =>
+      val filterOutKey = t.s2Edge.selectValues(fields)
+      !filterOutSet.contains(filterOutKey)
+    }
+
+    val grouped = for {
+      (key, (scoreSum, values)) <- baseStepResult.grouped
+      (out, in) = values.partition(v => filterOutSet.contains(v.s2Edge.selectValues(fields)))
+      newScoreSum = scoreSum - out.foldLeft(0.0) { case (prev, current) => prev + current.score } if in.nonEmpty
+    } yield key -> (newScoreSum, in)
+
+
+    StepResult(results = filteredResults, grouped = grouped, baseStepResult.degreeEdges)
+  }
+  def apply(graph: Graph,
+            queryOption: QueryOption,
+            stepInnerResult: StepInnerResult): StepResult = {
+        logger.debug(s"[BeforePostProcess]: ${stepInnerResult.edgesWithScoreLs.size}")
+
+    val results = for {
+      edgeWithScore <- stepInnerResult.edgesWithScoreLs
+    } yield {
+        val edge = edgeWithScore.edge
+        val orderByValues =
+          if (queryOption.orderByColumns.isEmpty) (edgeWithScore.score, None, None, None)
+          else toOrderByValues(edge, edgeWithScore.score, queryOption.orderByKeys)
+
+        S2EdgeWithScore(edge, edgeWithScore.score, orderByValues, edgeWithScore.edge.parentEdges)
+      }
+    /** ordered flatten result */
+    val ordered = orderBy(queryOption, results)
+
+    /** ordered grouped result */
+    val grouped =
+      if (queryOption.groupBy.keys.isEmpty) Nil
+      else {
+        val agg = new mutable.HashMap[GroupByKey, (Double, Values)]()
+        results.groupBy { s2EdgeWithScore =>
+          s2EdgeWithScore.s2Edge.selectValues(queryOption.groupBy.keys, useToString = true)
+        }.map { case (k, ls) =>
+          val (scoreSum, merged) = mergeOrdered(ls, Nil, queryOption)
+          /**
+           * watch out here. by calling toString on Any, we lose type information which will be used
+           * later for toJson.
+           */
+          if (merged.nonEmpty) {
+            val newKey = merged.head.s2Edge.selectValues(queryOption.groupBy.keys, useToString = false)
+            agg += (newKey -> (scoreSum, merged))
+          }
+        }
+        agg.toSeq.sortBy(_._2._1 * -1)
+      }
+
+    val degrees = stepInnerResult.degreeEdges.map(t => S2EdgeWithScore(t.edge, t.score))
+    StepResult(results = ordered, grouped = grouped, degreeEdges = degrees)
+  }
+}
+
+case class S2EdgeWithScore(s2Edge: Edge,
+                           score: Double,
+                           orderByValues: (Any, Any, Any, Any) = StepResult.EmptyOrderByValues,
+                           parentEdges: Seq[EdgeWithScore] = Nil)
+
+case class StepResult(results: StepResult.Values,
+                      grouped: Seq[(StepResult.GroupByKey, (Double, StepResult.Values))],
+                      degreeEdges: StepResult.Values) {
+  val isEmpty = results.isEmpty
+}

--- a/s2core/src/main/scala/org/apache/s2graph/core/mysqls/Experiment.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/mysqls/Experiment.scala
@@ -25,7 +25,8 @@ import scalikejdbc._
 import scala.util.Random
 
 object Experiment extends Model[Experiment] {
-  val impressionKey = "S2-Impression-Id"
+  val ImpressionKey = "S2-Impression-Id"
+  val ImpressionId = "Impression-Id"
 
   def apply(rs: WrappedResultSet): Experiment = {
     Experiment(rs.intOpt("id"),

--- a/s2core/src/main/scala/org/apache/s2graph/core/parsers/WhereParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/parsers/WhereParser.scala
@@ -22,7 +22,7 @@ package org.apache.s2graph.core.parsers
 import org.apache.s2graph.core.GraphExceptions.WhereParserException
 import org.apache.s2graph.core.mysqls.{Label, LabelMeta}
 import org.apache.s2graph.core.types.InnerValLike
-import org.apache.s2graph.core.{Edge, GraphExceptions, JSONParser}
+import org.apache.s2graph.core.Edge
 import org.apache.s2graph.core.JSONParser._
 import scala.annotation.tailrec
 import scala.util.Try

--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RestHandler.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RestHandler.scala
@@ -21,7 +21,8 @@ package org.apache.s2graph.core.rest
 
 import java.net.URL
 
-import org.apache.s2graph.core.GraphExceptions.BadQueryException
+import org.apache.s2graph.core.GraphExceptions.{BadQueryException, LabelNotExistException}
+import org.apache.s2graph.core.JSONParser._
 import org.apache.s2graph.core._
 import org.apache.s2graph.core.mysqls.{Bucket, Experiment, Service}
 import org.apache.s2graph.core.utils.logger
@@ -29,8 +30,21 @@ import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
 object RestHandler {
+  trait CanLookup[A] {
+    def lookup(m: A, key: String): Option[String]
+  }
+
+  object CanLookup {
+   implicit val oneTupleLookup = new CanLookup[(String, String)] {
+      override def lookup(m: (String, String), key: String) =
+        if (m._1 == key) Option(m._2) else None
+    }
+    implicit val hashMapLookup = new CanLookup[Map[String, String]] {
+      override def lookup(m: Map[String, String], key: String): Option[String] = m.get(key)
+    }
+  }
+
   case class HandlerResult(body: Future[JsValue], headers: (String, String)*)
 }
 
@@ -41,25 +55,31 @@ object RestHandler {
 class RestHandler(graph: Graph)(implicit ec: ExecutionContext) {
 
   import RestHandler._
-  val requestParser = new RequestParser(graph.config)
+  val requestParser = new RequestParser(graph)
+
 
   /**
     * Public APIS
     */
-  def doPost(uri: String, body: String, impKeyOpt: => Option[String] = None): HandlerResult = {
+  def doPost[A](uri: String, body: String, headers: A)(implicit ev: CanLookup[A]): HandlerResult = {
+    val impKeyOpt = ev.lookup(headers, Experiment.ImpressionKey)
+    val impIdOpt = ev.lookup(headers, Experiment.ImpressionId)
+
     try {
       val jsQuery = Json.parse(body)
 
       uri match {
-        case "/graphs/getEdges" => HandlerResult(getEdgesAsync(jsQuery)(PostProcess.toSimpleVertexArrJson))
-        case "/graphs/getEdges/grouped" => HandlerResult(getEdgesAsync(jsQuery)(PostProcess.summarizeWithListFormatted))
-        case "/graphs/getEdgesExcluded" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.toSimpleVertexArrJson))
-        case "/graphs/getEdgesExcluded/grouped" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExcludeFormatted))
+//        case "/graphs/getEdges" => HandlerResult(getEdgesAsync(jsQuery, impIdOpt)(PostProcess.toSimpleVertexArrJson))
+        case "/graphs/getEdges" => HandlerResult(getEdgesAsync(jsQuery, impIdOpt)(PostProcess.toJson))
+//        case "/graphs/getEdges/grouped" => HandlerResult(getEdgesAsync(jsQuery)(PostProcess.summarizeWithListFormatted))
+//        case "/graphs/getEdgesExcluded" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.toSimpleVertexArrJson))
+//        case "/graphs/getEdgesExcluded/grouped" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExcludeFormatted))
         case "/graphs/checkEdges" => checkEdges(jsQuery)
-        case "/graphs/getEdgesGrouped" => HandlerResult(getEdgesAsync(jsQuery)(PostProcess.summarizeWithList))
-        case "/graphs/getEdgesGroupedExcluded" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExclude))
-        case "/graphs/getEdgesGroupedExcludedFormatted" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExcludeFormatted))
+//        case "/graphs/getEdgesGrouped" => HandlerResult(getEdgesAsync(jsQuery)(PostProcess.summarizeWithList))
+//        case "/graphs/getEdgesGroupedExcluded" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExclude))
+//        case "/graphs/getEdgesGroupedExcludedFormatted" => HandlerResult(getEdgesExcludedAsync(jsQuery)(PostProcess.summarizeWithListExcludeFormatted))
         case "/graphs/getVertices" => HandlerResult(getVertices(jsQuery))
+        case "/graphs/experiments" => experiments(jsQuery)
         case uri if uri.startsWith("/graphs/experiment") =>
           val Array(accessToken, experimentName, uuid) = uri.split("/").takeRight(3)
           experiment(jsQuery, accessToken, experimentName, uuid, impKeyOpt)
@@ -75,17 +95,8 @@ class RestHandler(graph: Graph)(implicit ec: ExecutionContext) {
     try {
       val (quads, isReverted) = requestParser.toCheckEdgeParam(jsValue)
 
-      HandlerResult(graph.checkEdges(quads).map { case queryRequestWithResultLs =>
-        val edgeJsons = for {
-          queryRequestWithResult <- queryRequestWithResultLs
-          (queryRequest, queryResult) = QueryRequestWithResult.unapply(queryRequestWithResult).get
-          edgeWithScore <- queryResult.edgeWithScoreLs
-          (edge, score) = EdgeWithScore.unapply(edgeWithScore).get
-          convertedEdge = if (isReverted) edge.duplicateEdge else edge
-          edgeJson = PostProcess.edgeToJson(convertedEdge, score, queryRequest.query, queryRequest.queryParam)
-        } yield Json.toJson(edgeJson)
-
-        Json.toJson(edgeJsons)
+      HandlerResult(graph.checkEdges(quads).map { case stepResult =>
+        PostProcess.toJson(graph, QueryOption(), stepResult)
       })
     } catch {
       case e: Exception => HandlerResult(Future.failed(e))
@@ -93,11 +104,23 @@ class RestHandler(graph: Graph)(implicit ec: ExecutionContext) {
   }
 
 
-  /**
-    * Private APIS
-    */
-  private def experiment(contentsBody: JsValue, accessToken: String, experimentName: String, uuid: String, impKeyOpt: => Option[String]): HandlerResult = {
+  private def experiments(jsQuery: JsValue): HandlerResult = {
+    val params: Seq[RequestParser.ExperimentParam] = requestParser.parseExperiment(jsQuery)
 
+    val results = params map { case (body, token, experimentName, uuid, impKeyOpt) =>
+      val handlerResult = experiment(body, token, experimentName, uuid, impKeyOpt)
+      val future = handlerResult.body.recover {
+        case e: Exception => PostProcess.emptyResults ++ Json.obj("error" -> Json.obj("reason" -> e.getMessage))
+      }
+
+      future
+    }
+
+    val result = Future.sequence(results).map(JsArray)
+    HandlerResult(body = result)
+  }
+
+  private def experiment(contentsBody: JsValue, accessToken: String, experimentName: String, uuid: String, impKeyOpt: => Option[String] = None): HandlerResult = {
     try {
       val bucketOpt = for {
         service <- Service.findByAccessToken(accessToken)
@@ -108,7 +131,7 @@ class RestHandler(graph: Graph)(implicit ec: ExecutionContext) {
       val bucket = bucketOpt.getOrElse(throw new RuntimeException("bucket is not found"))
       if (bucket.isGraphQuery) {
         val ret = buildRequestInner(contentsBody, bucket, uuid)
-        HandlerResult(ret.body, Experiment.impressionKey -> bucket.impressionId)
+        HandlerResult(ret.body, Experiment.ImpressionKey -> bucket.impressionId)
       }
       else throw new RuntimeException("not supported yet")
     } catch {
@@ -127,119 +150,54 @@ class RestHandler(graph: Graph)(implicit ec: ExecutionContext) {
       val experimentLog = s"POST $path took -1 ms 200 -1 $body"
       logger.debug(experimentLog)
 
-      doPost(path, body)
+      doPost(path, body, Experiment.ImpressionId -> bucket.impressionId)
     }
   }
 
-  private def eachQuery(post: (Seq[QueryRequestWithResult], Seq[QueryRequestWithResult]) => JsValue)(q: Query): Future[JsValue] = {
-    val filterOutQueryResultsLs = q.filterOutQuery match {
-      case Some(filterOutQuery) => graph.getEdges(filterOutQuery)
-      case None => Future.successful(Seq.empty)
-    }
-
-    for {
-      queryResultsLs <- graph.getEdges(q)
-      filterOutResultsLs <- filterOutQueryResultsLs
-    } yield {
-      val json = post(queryResultsLs, filterOutResultsLs)
-      json
-    }
-  }
-
-  def getEdgesAsync(jsonQuery: JsValue)
-                   (post: (Seq[QueryRequestWithResult], Seq[QueryRequestWithResult]) => JsValue): Future[JsValue] = {
-
-    val fetch = eachQuery(post) _
+  def getEdgesAsync(jsonQuery: JsValue, impIdOpt: Option[String] = None)
+                   (post: (Graph, QueryOption, StepResult) => JsValue): Future[JsValue] = {
     jsonQuery match {
-      case JsArray(arr) => Future.traverse(arr.map(requestParser.toQuery(_)))(fetch).map(JsArray)
       case obj@JsObject(_) =>
         (obj \ "queries").asOpt[JsValue] match {
-          case None => fetch(requestParser.toQuery(obj))
+          case None =>
+            val query = requestParser.toQuery(obj, impIdOpt)
+            graph.getEdges(query).map(post(graph, query.queryOption, _))
           case _ =>
-            val multiQuery = requestParser.toMultiQuery(obj)
-            val filterOutFuture = multiQuery.queryOption.filterOutQuery match {
-              case Some(filterOutQuery) => graph.getEdges(filterOutQuery)
-              case None => Future.successful(Seq.empty)
-            }
-            val futures = multiQuery.queries.zip(multiQuery.weights).map { case (query, weight) =>
-              val filterOutQueryResultsLs = query.queryOption.filterOutQuery match {
-                case Some(filterOutQuery) => graph.getEdges(filterOutQuery)
-                case None => Future.successful(Seq.empty)
-              }
-              for {
-                queryRequestWithResultLs <- graph.getEdges(query)
-                filterOutResultsLs <- filterOutQueryResultsLs
-              } yield {
-                val newQueryRequestWithResult = for {
-                  queryRequestWithResult <- queryRequestWithResultLs
-                  queryResult = queryRequestWithResult.queryResult
-                } yield {
-                  val newEdgesWithScores = for {
-                    edgeWithScore <- queryRequestWithResult.queryResult.edgeWithScoreLs
-                  } yield {
-                    edgeWithScore.copy(score = edgeWithScore.score * weight)
-                  }
-                  queryRequestWithResult.copy(queryResult = queryResult.copy(edgeWithScoreLs = newEdgesWithScores))
-                }
-                logger.debug(s"[Size]: ${newQueryRequestWithResult.map(_.queryResult.edgeWithScoreLs.size).sum}")
-                (newQueryRequestWithResult, filterOutResultsLs)
-              }
-            }
-            for {
-              filterOut <- filterOutFuture
-              resultWithExcludeLs <- Future.sequence(futures)
-            } yield {
-              PostProcess.toSimpleVertexArrJsonMulti(multiQuery.queryOption, resultWithExcludeLs, filterOut)
-              //              val initial = (ListBuffer.empty[QueryRequestWithResult], ListBuffer.empty[QueryRequestWithResult])
-              //              val (results, excludes) = resultWithExcludeLs.foldLeft(initial) { case ((prevResults, prevExcludes), (results, excludes)) =>
-              //                (prevResults ++= results, prevExcludes ++= excludes)
-              //              }
-              //              PostProcess.toSimpleVertexArrJson(multiQuery.queryOption, results, excludes ++ filterOut)
-            }
+            val multiQuery = requestParser.toMultiQuery(obj, impIdOpt)
+            graph.getEdgesMultiQuery(multiQuery).map(post(graph, multiQuery.queryOption, _))
         }
+
+      case JsArray(arr) =>
+        val queries = arr.map(requestParser.toQuery(_, impIdOpt))
+        val weights = queries.map(_ => 1.0)
+        val multiQuery = MultiQuery(queries, weights, QueryOption(), jsonQuery)
+        graph.getEdgesMultiQuery(multiQuery).map(post(graph, multiQuery.queryOption, _))
+
       case _ => throw BadQueryException("Cannot support")
-    }
-  }
-
-  private def getEdgesExcludedAsync(jsonQuery: JsValue)
-                                   (post: (Seq[QueryRequestWithResult], Seq[QueryRequestWithResult]) => JsValue): Future[JsValue] = {
-    val q = requestParser.toQuery(jsonQuery)
-    val filterOutQuery = Query(q.vertices, Vector(q.steps.last))
-
-    val fetchFuture = graph.getEdges(q)
-    val excludeFuture = graph.getEdges(filterOutQuery)
-
-    for {
-      queryResultLs <- fetchFuture
-      exclude <- excludeFuture
-    } yield {
-      post(queryResultLs, exclude)
     }
   }
 
   private def getVertices(jsValue: JsValue) = {
     val jsonQuery = jsValue
-    val ts = System.currentTimeMillis()
-    val props = "{}"
 
     val vertices = jsonQuery.as[List[JsValue]].flatMap { js =>
       val serviceName = (js \ "serviceName").as[String]
       val columnName = (js \ "columnName").as[String]
-      for (id <- (js \ "ids").asOpt[List[JsValue]].getOrElse(List.empty[JsValue])) yield {
-        Management.toVertex(ts, "insert", id.toString, serviceName, columnName, props)
+      for {
+        idJson <- (js \ "ids").asOpt[List[JsValue]].getOrElse(List.empty[JsValue])
+        id <- jsValueToAny(idJson)
+      } yield {
+        Vertex.toVertex(serviceName, columnName, id)
       }
     }
 
     graph.getVertices(vertices) map { vertices => PostProcess.verticesToJson(vertices) }
   }
 
+
   private def buildRequestBody(requestKeyJsonOpt: Option[JsValue], bucket: Bucket, uuid: String): String = {
     var body = bucket.requestBody.replace("#uuid", uuid)
 
-    //    // replace variable
-    //    body = TemplateHelper.replaceVariable(System.currentTimeMillis(), body)
-
-    // replace param
     for {
       requestKeyJson <- requestKeyJsonOpt
       jsObj <- requestKeyJson.asOpt[JsObject]

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/serde/indexedge/wide/IndexEdgeSerializable.scala
@@ -63,5 +63,5 @@ class IndexEdgeSerializable(indexEdge: IndexEdge) extends Serializable[IndexEdge
     else if (indexEdge.op == GraphUtil.operations("incrementCount"))
       Bytes.toBytes(indexEdge.props(LabelMeta.countSeq).innerVal.toString().toLong)
     else propsToKeyValues(indexEdge.metas.toSeq)
-  
+
  }

--- a/s2core/src/main/scala/org/apache/s2graph/core/utils/Logger.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/utils/Logger.scala
@@ -51,6 +51,8 @@ object logger {
   private val logger = LoggerFactory.getLogger("application")
   private val errorLogger = LoggerFactory.getLogger("error")
   private val metricLogger = LoggerFactory.getLogger("metrics")
+  private val queryLogger = LoggerFactory.getLogger("query")
+  private val malformedLogger = LoggerFactory.getLogger("malformed")
 
   def metric[T: Loggable](msg: => T) = metricLogger.info(implicitly[Loggable[T]].toLogMessage(msg))
 
@@ -61,6 +63,10 @@ object logger {
   def error[T: Loggable](msg: => T, exception: => Throwable) = errorLogger.error(implicitly[Loggable[T]].toLogMessage(msg), exception)
 
   def error[T: Loggable](msg: => T) = errorLogger.error(implicitly[Loggable[T]].toLogMessage(msg))
+
+  def query[T: Loggable](msg: => T) = queryLogger.info(implicitly[Loggable[T]].toLogMessage(msg))
+
+  def malformed[T: Loggable](msg: => T, exception: => Throwable) = malformedLogger.error(implicitly[Loggable[T]].toLogMessage(msg), exception)
 }
 
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/EdgeTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/EdgeTest.scala
@@ -19,10 +19,12 @@
 
 package org.apache.s2graph.core
 
+import org.apache.s2graph.core.JSONParser._
 import org.apache.s2graph.core.mysqls.LabelMeta
 import org.apache.s2graph.core.types.{InnerVal, InnerValLikeWithTs, VertexId}
 import org.apache.s2graph.core.utils.logger
 import org.scalatest.FunSuite
+import play.api.libs.json.{JsObject, Json}
 
 class EdgeTest extends FunSuite with TestCommon with TestCommonWithModels {
   initTests()
@@ -39,7 +41,8 @@ class EdgeTest extends FunSuite with TestCommon with TestCommonWithModels {
     val (srcId, tgtId, labelName) = ("1", "2", testLabelName)
 
     val bulkEdge = (for ((ts, op, props) <- bulkQueries) yield {
-      Management.toEdge(ts.toLong, op, srcId, tgtId, labelName, "out", props).toLogString
+      val properties = fromJsonToProperties(Json.parse(props).as[JsObject])
+      Edge.toEdge(srcId, tgtId, labelName, "out", properties, ts.toLong, op).toLogString
     }).mkString("\n")
 
     val expected = Seq(

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/CrudTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/CrudTest.scala
@@ -20,27 +20,27 @@
 package org.apache.s2graph.core.Integrate
 
 import org.apache.s2graph.core.mysqls.{Label, LabelMeta}
+import org.apache.s2graph.core.utils.logger
 import play.api.libs.json.{JsObject, Json}
 
 class CrudTest extends IntegrateCommon {
   import CrudHelper._
   import TestUtil._
 
-  test("test CRUD") {
-    var tcNum = 0
-    var tcString = ""
-    var bulkQueries = List.empty[(Long, String, String)]
-    var expected = Map.empty[String, String]
+  var tcString = ""
+  var bulkQueries = List.empty[(Long, String, String)]
+  var expected = Map.empty[String, String]
 
-    val curTime = System.currentTimeMillis
-    val t1 = curTime + 0
-    val t2 = curTime + 1
-    val t3 = curTime + 2
-    val t4 = curTime + 3
-    val t5 = curTime + 4
+  val curTime = System.currentTimeMillis
+  val t1 = curTime + 0
+  val t2 = curTime + 1
+  val t3 = curTime + 2
+  val t4 = curTime + 3
+  val t5 = curTime + 4
 
-    val tcRunner = new CrudTestRunner()
-    tcNum = 1
+  val tcRunner = new CrudTestRunner()
+  test("1: [t1 -> t2 -> t3 test case] insert(t1) delete(t2) insert(t3) test") {
+    val tcNum = 1
     tcString = "[t1 -> t2 -> t3 test case] insert(t1) delete(t2) insert(t3) test "
 
     bulkQueries = List(
@@ -50,8 +50,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 2
+  }
+  test("2: [t1 -> t2 -> t3 test case] insert(t1) delete(t2) insert(t3) test") {
+    val tcNum = 2
     tcString = "[t1 -> t2 -> t3 test case] insert(t1) delete(t2) insert(t3) test "
     bulkQueries = List(
       (t1, "insert", "{\"time\": 10}"),
@@ -60,8 +61,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 3
+  }
+  test("3: [t3 -> t2 -> t1 test case] insert(t3) delete(t2) insert(t1) test") {
+    val tcNum = 3
     tcString = "[t3 -> t2 -> t1 test case] insert(t3) delete(t2) insert(t1) test "
     bulkQueries = List(
       (t3, "insert", "{\"time\": 10, \"weight\": 20}"),
@@ -70,8 +72,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 4
+  }
+  test("4: [t3 -> t1 -> t2 test case] insert(t3) insert(t1) delete(t2) test") {
+    val tcNum = 4
     tcString = "[t3 -> t1 -> t2 test case] insert(t3) insert(t1) delete(t2) test "
     bulkQueries = List(
       (t3, "insert", "{\"time\": 10, \"weight\": 20}"),
@@ -80,8 +83,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 5
+  }
+  test("5: [t2 -> t1 -> t3 test case] delete(t2) insert(t1) insert(t3) test") {
+    val tcNum = 5
     tcString = "[t2 -> t1 -> t3 test case] delete(t2) insert(t1) insert(t3) test"
     bulkQueries = List(
       (t2, "delete", ""),
@@ -90,8 +94,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 6
+  }
+  test("6: [t2 -> t3 -> t1 test case] delete(t2) insert(t3) insert(t1) test") {
+    val tcNum = 6
     tcString = "[t2 -> t3 -> t1 test case] delete(t2) insert(t3) insert(t1) test "
     bulkQueries = List(
       (t2, "delete", ""),
@@ -100,8 +105,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 7
+  }
+  test("7: [t1 -> t2 -> t3 test case] update(t1) delete(t2) update(t3) test ") {
+    val tcNum = 7
     tcString = "[t1 -> t2 -> t3 test case] update(t1) delete(t2) update(t3) test "
     bulkQueries = List(
       (t1, "update", "{\"time\": 10}"),
@@ -110,7 +116,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-    tcNum = 8
+  }
+  test("8: [t1 -> t3 -> t2 test case] update(t1) update(t3) delete(t2) test ") {
+    val tcNum = 8
     tcString = "[t1 -> t3 -> t2 test case] update(t1) update(t3) delete(t2) test "
     bulkQueries = List(
       (t1, "update", "{\"time\": 10}"),
@@ -119,7 +127,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-    tcNum = 9
+  }
+  test("9: [t2 -> t1 -> t3 test case] delete(t2) update(t1) update(t3) test") {
+    val tcNum = 9
     tcString = "[t2 -> t1 -> t3 test case] delete(t2) update(t1) update(t3) test "
     bulkQueries = List(
       (t2, "delete", ""),
@@ -128,7 +138,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-    tcNum = 10
+  }
+  test("10: [t2 -> t3 -> t1 test case] delete(t2) update(t3) update(t1) test") {
+    val tcNum = 10
     tcString = "[t2 -> t3 -> t1 test case] delete(t2) update(t3) update(t1) test"
     bulkQueries = List(
       (t2, "delete", ""),
@@ -137,7 +149,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-    tcNum = 11
+  }
+  test("11: [t3 -> t2 -> t1 test case] update(t3) delete(t2) update(t1) test") {
+    val tcNum = 11
     tcString = "[t3 -> t2 -> t1 test case] update(t3) delete(t2) update(t1) test "
     bulkQueries = List(
       (t3, "update", "{\"time\": 10, \"weight\": 20}"),
@@ -146,7 +160,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-    tcNum = 12
+  }
+  test("12: [t3 -> t1 -> t2 test case] update(t3) update(t1) delete(t2) test") {
+    val tcNum = 12
     tcString = "[t3 -> t1 -> t2 test case] update(t3) update(t1) delete(t2) test "
     bulkQueries = List(
       (t3, "update", "{\"time\": 10, \"weight\": 20}"),
@@ -155,8 +171,9 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "10", "weight" -> "20")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
-
-    tcNum = 13
+  }
+  test("13: [t5 -> t1 -> t3 -> t2 -> t4 test case] update(t5) insert(t1) insert(t3) delete(t2) update(t4) test ") {
+    val tcNum = 13
     tcString = "[t5 -> t1 -> t3 -> t2 -> t4 test case] update(t5) insert(t1) insert(t3) delete(t2) update(t4) test "
     bulkQueries = List(
       (t5, "update", "{\"is_blocked\": true}"),
@@ -167,6 +184,15 @@ class CrudTest extends IntegrateCommon {
     expected = Map("time" -> "1", "weight" -> "-10", "is_hidden" -> "false", "is_blocked" -> "true")
 
     tcRunner.run(tcNum, tcString, bulkQueries, expected)
+  }
+
+  test("14 - test lock expire") {
+    for {
+      labelName <- List(testLabelName, testLabelName2)
+    } {
+      val id = 0
+      tcRunner.expireTC(labelName, id)
+    }
   }
 
 
@@ -191,7 +217,7 @@ class CrudTest extends IntegrateCommon {
           val bulkEdges = (for ((ts, op, props) <- opWithProps) yield {
             TestUtil.toEdge(ts, op, "e", srcId, tgtId, labelName, props)
           })
-
+          println(s"${bulkEdges.mkString("\n")}")
           TestUtil.insertEdgesSync(bulkEdges: _*)
 
           for {
@@ -210,6 +236,7 @@ class CrudTest extends IntegrateCommon {
             val jsResult = TestUtil.getEdgesSync(query)
 
             val results = jsResult \ "results"
+
             val deegrees = (jsResult \ "degrees").as[List[JsObject]]
             val propsLs = (results \\ "props").seq
             (deegrees.head \ LabelMeta.degree.name).as[Int] should be(1)
@@ -229,6 +256,63 @@ class CrudTest extends IntegrateCommon {
         }
       }
 
+      def expireTC(labelName: String, id: Int) = {
+        var i = 1
+        val label = Label.findByName(labelName).get
+        val serviceName = label.serviceName
+        val columnName = label.srcColumnName
+        val id = 0
+
+        while (i < 1000) {
+          val bulkEdges = Seq(TestUtil.toEdge(i, "u", "e", id, id, testLabelName, Json.obj("time" -> 10).toString()))
+          val rets = TestUtil.insertEdgesSync(bulkEdges: _*)
+
+
+          val queryJson = querySnapshotEdgeJson(serviceName, columnName, labelName, id)
+
+          if (!rets.forall(identity)) {
+            Thread.sleep(graph.storage.LockExpireDuration + 100)
+            /** expect current request would be ignored */
+            val bulkEdges = Seq(TestUtil.toEdge(i-1, "u", "e", 0, 0, testLabelName, Json.obj("time" -> 20).toString()))
+            val rets = TestUtil.insertEdgesSync(bulkEdges: _*)
+            if (rets.forall(identity)) {
+              // check
+              val jsResult = TestUtil.getEdgesSync(queryJson)
+              (jsResult \\ "time").head.as[Int] should be(10)
+              logger.debug(jsResult)
+              i = 100000
+            }
+          }
+
+          i += 1
+        }
+
+        i = 1
+        while (i < 1000) {
+          val bulkEdges = Seq(TestUtil.toEdge(i, "u", "e", id, id, testLabelName, Json.obj("time" -> 10).toString()))
+          val rets = TestUtil.insertEdgesSync(bulkEdges: _*)
+
+
+          val queryJson = querySnapshotEdgeJson(serviceName, columnName, labelName, id)
+
+          if (!rets.forall(identity)) {
+            Thread.sleep(graph.storage.LockExpireDuration + 100)
+            /** expect current request would be applied */
+            val bulkEdges = Seq(TestUtil.toEdge(i+1, "u", "e", 0, 0, testLabelName, Json.obj("time" -> 20).toString()))
+            val rets = TestUtil.insertEdgesSync(bulkEdges: _*)
+            if (rets.forall(identity)) {
+              // check
+              val jsResult = TestUtil.getEdgesSync(queryJson)
+              (jsResult \\ "time").head.as[Int] should be(20)
+              logger.debug(jsResult)
+              i = 100000
+            }
+          }
+
+          i += 1
+        }
+      }
+
       def queryJson(serviceName: String, columnName: String, labelName: String, id: String, dir: String, cacheTTL: Long = -1L) = Json.parse(
         s""" { "srcVertices": [
              { "serviceName": "$serviceName",
@@ -240,6 +324,15 @@ class CrudTest extends IntegrateCommon {
              "offset": 0,
              "limit": 10,
              "cacheTTL": $cacheTTL }]]}""")
+
+      def querySnapshotEdgeJson(serviceName: String, columnName: String, labelName: String, id: Int) = Json.parse(
+        s""" { "srcVertices": [
+             { "serviceName": "$serviceName",
+               "columnName": "$columnName",
+               "id": $id } ],
+             "steps": [ [ {
+             "label": "$labelName",
+             "_to": $id }]]}""")
     }
   }
 }

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/QueryTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/QueryTest.scala
@@ -307,7 +307,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
               "label": "$testLabelName",
               "direction": "in",
               "offset": 0,
-              "limit": 10
+              "limit": 1000
             }
           ]]
         }""".stripMargin)
@@ -328,54 +328,54 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
 
 
 
-//  test("pagination and _to") {
-//    def querySingleWithTo(id: Int, offset: Int = 0, limit: Int = 100, to: Int) = Json.parse(
-//      s"""
-//        { "srcVertices": [
-//          { "serviceName": "${testServiceName}",
-//            "columnName": "${testColumnName}",
-//            "id": ${id}
-//           }],
-//          "steps": [
-//          [ {
-//              "label": "${testLabelName}",
-//              "direction": "out",
-//              "offset": $offset,
-//              "limit": $limit,
-//              "_to": $to
-//            }
-//          ]]
-//        }
-//        """)
-//
-//    val src = System.currentTimeMillis().toInt
-//
-//    val bulkEdges = Seq(
-//      toEdge(1001, insert, e, src, 1, testLabelName, Json.obj(weight -> 10, is_hidden -> true)),
-//      toEdge(2002, insert, e, src, 2, testLabelName, Json.obj(weight -> 20, is_hidden -> false)),
-//      toEdge(3003, insert, e, src, 3, testLabelName, Json.obj(weight -> 30)),
-//      toEdge(4004, insert, e, src, 4, testLabelName, Json.obj(weight -> 40))
-//    )
-//    insertEdgesSync(bulkEdges: _*)
-//
-//    var result = getEdgesSync(querySingle(src, offset = 0, limit = 2))
-//    var edges = (result \ "results").as[List[JsValue]]
-//
-//    edges.size should be(2)
-//    (edges(0) \ "to").as[Long] should be(4)
-//    (edges(1) \ "to").as[Long] should be(3)
-//
-//    result = getEdgesSync(querySingle(src, offset = 1, limit = 2))
-//
-//    edges = (result \ "results").as[List[JsValue]]
-//    edges.size should be(2)
-//    (edges(0) \ "to").as[Long] should be(3)
-//    (edges(1) \ "to").as[Long] should be(2)
-//
-//    result = getEdgesSync(querySingleWithTo(src, offset = 0, limit = -1, to = 1))
-//    edges = (result \ "results").as[List[JsValue]]
-//    edges.size should be(1)
-//  }
+  test("pagination and _to") {
+    def querySingleWithTo(id: Int, offset: Int = 0, limit: Int = 100, to: Int) = Json.parse(
+      s"""
+        { "srcVertices": [
+          { "serviceName": "${testServiceName}",
+            "columnName": "${testColumnName}",
+            "id": ${id}
+           }],
+          "steps": [
+          [ {
+              "label": "${testLabelName}",
+              "direction": "out",
+              "offset": $offset,
+              "limit": $limit,
+              "_to": $to
+            }
+          ]]
+        }
+        """)
+
+    val src = System.currentTimeMillis().toInt
+
+    val bulkEdges = Seq(
+      toEdge(1001, insert, e, src, 1, testLabelName, Json.obj(weight -> 10, is_hidden -> true)),
+      toEdge(2002, insert, e, src, 2, testLabelName, Json.obj(weight -> 20, is_hidden -> false)),
+      toEdge(3003, insert, e, src, 3, testLabelName, Json.obj(weight -> 30)),
+      toEdge(4004, insert, e, src, 4, testLabelName, Json.obj(weight -> 40))
+    )
+    insertEdgesSync(bulkEdges: _*)
+
+    var result = getEdgesSync(querySingle(src, offset = 0, limit = 2))
+    var edges = (result \ "results").as[List[JsValue]]
+
+    edges.size should be(2)
+    (edges(0) \ "to").as[Long] should be(4)
+    (edges(1) \ "to").as[Long] should be(3)
+
+    result = getEdgesSync(querySingle(src, offset = 1, limit = 2))
+
+    edges = (result \ "results").as[List[JsValue]]
+    edges.size should be(2)
+    (edges(0) \ "to").as[Long] should be(3)
+    (edges(1) \ "to").as[Long] should be(2)
+
+    result = getEdgesSync(querySingleWithTo(src, offset = 0, limit = -1, to = 1))
+    edges = (result \ "results").as[List[JsValue]]
+    edges.size should be(1)
+  }
 
   test("order by") {
     def queryScore(id: Int, scoring: Map[String, Int]): JsValue = Json.obj(
@@ -907,7 +907,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
        """.stripMargin
     )
 
-    def querySingleVertexWithOp(id: String, op: String, shrinkageVal: Long) = Json.parse(
+    def queryWithOp(ids: Seq[String], op: String, shrinkageVal: Long) = Json.parse(
       s"""{
          |  "limit": 10,
          |  "groupBy": ["from"],
@@ -916,7 +916,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
          |    {
          |      "serviceName": "$testServiceName",
          |      "columnName": "$testColumnName",
-         |      "id": $id
+         |      "ids": [${ids.mkString(",")}]
          |    }
          |  ],
          |  "steps": [
@@ -949,47 +949,6 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
        """.stripMargin
     )
 
-    def queryMultiVerticesWithOp(id: String, id2: String, op: String, shrinkageVal: Long) = Json.parse(
-      s"""{
-         |  "limit": 10,
-         |  "groupBy": ["from"],
-         |  "duplicate": "sum",
-         |  "srcVertices": [
-         |    {
-         |      "serviceName": "$testServiceName",
-         |      "columnName": "$testColumnName",
-         |      "ids": [$id, $id2]
-         |    }
-         |  ],
-         |  "steps": [
-         |    {
-         |      "step": [
-         |        {
-         |          "label": "$testLabelName",
-         |          "direction": "out",
-         |          "offset": 0,
-         |          "limit": 10,
-         |          "groupBy": ["from"],
-         |          "duplicate": "countSum",
-         |          "transform": [["_from"]]
-         |        }
-         |      ]
-         |    }, {
-         |      "step": [
-         |        {
-         |          "label": "$testLabelName2",
-         |          "direction": "out",
-         |          "offset": 0,
-         |          "limit": 10,
-         |          "scorePropagateOp": "$op",
-         |          "scorePropagateShrinkage": $shrinkageVal
-         |        }
-         |      ]
-         |    }
-         |  ]
-         |}
-       """.stripMargin
-    )
     val testId = "-30000"
     val testId2 = "-4000"
 
@@ -1014,15 +973,15 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
     val secondStepEdgeCount = 4l
 
     var shrinkageVal = 10l
-    var rs = getEdgesSync(querySingleVertexWithOp(testId, "divide", shrinkageVal))
-    logger.debug(Json.prettyPrint(rs))
+    var rs = getEdgesSync(queryWithOp(Seq(testId), "divide", shrinkageVal))
+
     var results = (rs \ "results").as[List[JsValue]]
     results.size should be(1)
     var scoreSum = secondStepEdgeCount.toDouble / (firstStepEdgeCount.toDouble + shrinkageVal)
     (results(0) \ "scoreSum").as[Double] should be(scoreSum)
 
-    rs = getEdgesSync(queryMultiVerticesWithOp(testId, testId2, "divide", shrinkageVal))
-    logger.debug(Json.prettyPrint(rs))
+    rs = getEdgesSync(queryWithOp(Seq(testId, testId2), "divide", shrinkageVal))
+
     results = (rs \ "results").as[List[JsValue]]
     results.size should be(2)
     scoreSum = secondStepEdgeCount.toDouble / (firstStepEdgeCount.toDouble + shrinkageVal)
@@ -1033,21 +992,21 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
     // check for divide zero case
     shrinkageVal = 30l
     rs = getEdgesSync(queryWithPropertyOp(testId, "divide", shrinkageVal))
-    logger.debug(Json.prettyPrint(rs))
+
     results = (rs \ "results").as[List[JsValue]]
     results.size should be(1)
     (results(0) \ "scoreSum").as[Double] should be(0)
 
     // "plus" operation
-    rs = getEdgesSync(querySingleVertexWithOp(testId, "plus", shrinkageVal))
-    logger.debug(Json.prettyPrint(rs))
+    rs = getEdgesSync(queryWithOp(Seq(testId), "plus", shrinkageVal))
+
     results = (rs \ "results").as[List[JsValue]]
     results.size should be(1)
     scoreSum = (firstStepEdgeCount + 1) * secondStepEdgeCount
     (results(0) \ "scoreSum").as[Long] should be(scoreSum)
 
     // "multiply" operation
-    rs = getEdgesSync(querySingleVertexWithOp(testId, "multiply", shrinkageVal))
+    rs = getEdgesSync(queryWithOp(Seq(testId), "multiply", shrinkageVal))
     logger.debug(Json.prettyPrint(rs))
     results = (rs \ "results").as[List[JsValue]]
     results.size should be(1)

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/StrongLabelDeleteTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/StrongLabelDeleteTest.scala
@@ -141,11 +141,12 @@ class StrongLabelDeleteTest extends IntegrateCommon {
   test("large degrees") {
     val labelName = testLabelName2
     val dir = "out"
+    val minSize = 0
     val maxSize = 100
     val deleteSize = 10
     val numOfConcurrentBatch = 100
-    val src = System.currentTimeMillis()
-    val tgts = (0 until maxSize).map { ith => src + ith }
+    val src = 1092983
+    val tgts = (minSize until maxSize).map { ith => src + ith }
     val deleteTgts = Random.shuffle(tgts).take(deleteSize)
     val insertRequests = tgts.map { tgt =>
       Seq(tgt, "insert", "e", src, tgt, labelName, "{}", dir).mkString("\t")
@@ -181,11 +182,12 @@ class StrongLabelDeleteTest extends IntegrateCommon {
   test("deleteAll") {
     val labelName = testLabelName2
     val dir = "out"
-    val maxSize = 100
+    val minSize = 200
+    val maxSize = 300
     val deleteSize = 10
     val numOfConcurrentBatch = 100
-    val src = System.currentTimeMillis()
-    val tgts = (0 until maxSize).map { ith => src + ith }
+    val src = 192338237
+    val tgts = (minSize until maxSize).map { ith => src + ith }
     val deleteTgts = Random.shuffle(tgts).take(deleteSize)
     val insertRequests = tgts.map { tgt =>
       Seq(tgt, "insert", "e", src, tgt, labelName, "{}", dir).mkString("\t")
@@ -220,7 +222,7 @@ class StrongLabelDeleteTest extends IntegrateCommon {
 //    val labelName = testLabelName
     val maxTgtId = 10
     val batchSize = 10
-    val testNum = 100
+    val testNum = 10
     val numOfBatch = 10
 
     def testInner(startTs: Long, src: Long) = {

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/VertexTestHelper.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/VertexTestHelper.scala
@@ -31,6 +31,8 @@ class VertexTestHelper extends IntegrateCommon {
   import TestUtil._
   import VertexTestHelper._
 
+
+
   test("vertex") {
     val ids = (7 until 20).map(tcNum => tcNum * 1000 + 0)
     val (serviceName, columnName) = (testServiceName, testColumnName)
@@ -40,9 +42,10 @@ class VertexTestHelper extends IntegrateCommon {
     println(payload)
 
     val vertices = parser.toVertices(payload, "insert", Option(serviceName), Option(columnName))
-    Await.result(graph.mutateVertices(vertices, withWait = true), HttpRequestWaitingTime)
+    val srcVertices = vertices
+    Await.result(graph.mutateVertices(srcVertices, withWait = true), HttpRequestWaitingTime)
 
-    val res = graph.getVertices(vertices).map { vertices =>
+    val res = graph.getVertices(srcVertices).map { vertices =>
       PostProcess.verticesToJson(vertices)
     }
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/WeakLabelDeleteTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/WeakLabelDeleteTest.scala
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,11 +33,12 @@ class WeakLabelDeleteTest extends IntegrateCommon with BeforeAndAfterEach {
   import WeakLabelDeleteHelper._
 
   test("test weak consistency select") {
+    insertEdgesSync(bulkEdges(): _*)
     var result = getEdgesSync(query(0))
-    println(result)
+
     (result \ "results").as[List[JsValue]].size should be(4)
     result = getEdgesSync(query(10))
-    println(result)
+
     (result \ "results").as[List[JsValue]].size should be(2)
   }
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/JsonParserTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/JsonParserTest.scala
@@ -19,9 +19,10 @@
 
 package org.apache.s2graph.core
 
-import org.apache.s2graph.core.types.{InnerVal, InnerValLike}
 import org.apache.s2graph.core.JSONParser._
+import org.apache.s2graph.core.types.{InnerVal, InnerValLike}
 import org.scalatest.{FunSuite, Matchers}
+
 
 class JsonParserTest extends FunSuite with Matchers with TestCommon {
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/TestCommonWithModels.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/TestCommonWithModels.scala
@@ -146,7 +146,7 @@ trait TestCommonWithModels {
       isDirected = true, serviceNameV4, testIdxProps, testProps, consistencyLevel, Some(hTableName), hTableTTL, VERSION4, false, "lg4", None)
 
     management.createLabel(undirectedLabelName, serviceName, columnName, columnType, serviceName, tgtColumnName, tgtColumnType,
-      isDirected = false, serviceName, testIdxProps, testProps, consistencyLevel, Some(hTableName), hTableTTL, VERSION1, false, "lg4", None)
+      isDirected = false, serviceName, testIdxProps, testProps, consistencyLevel, Some(hTableName), hTableTTL, VERSION3, false, "lg4", None)
 
     management.createLabel(undirectedLabelNameV2, serviceNameV2, columnNameV2, columnTypeV2, serviceNameV2, tgtColumnNameV2, tgtColumnTypeV2,
       isDirected = false, serviceName, testIdxProps, testProps, consistencyLevel, Some(hTableName), hTableTTL, VERSION2, false, "lg4", None)

--- a/s2core/src/test/scala/org/apache/s2graph/core/benchmark/JsonBenchmarkSpec.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/benchmark/JsonBenchmarkSpec.scala
@@ -23,41 +23,55 @@ import play.api.libs.json.JsNumber
 import play.libs.Json
 
 class JsonBenchmarkSpec extends BenchmarkCommon {
-  "to json" >> {
-    "json benchmark" >> {
 
-      duration("map to json") {
-        (0 to 10) foreach { n =>
-          val numberMaps = (0 to 100).map { n => (n.toString -> JsNumber(n * n)) }.toMap
-          Json.toJson(numberMaps)
+  "JsonBenchSpec" should {
+
+    "Json Append" >> {
+      import play.api.libs.json.{Json, _}
+      val numberJson = Json.toJson((0 to 1000).map { i => s"$i" -> JsNumber(i * i) }.toMap).as[JsObject]
+
+      /** dummy warm-up **/
+      (0 to 10000) foreach { n =>
+        Json.obj(s"$n" -> "dummy") ++ numberJson
+      }
+      (0 to 10000) foreach { n =>
+        Json.obj(s"$n" -> numberJson)
+      }
+
+      duration("Append by JsObj ++ JsObj ") {
+        (0 to 100000) foreach { n =>
+          numberJson ++ Json.obj(s"$n" -> "dummy")
         }
       }
 
-      duration("directMakeJson") {
-        (0 to 10) foreach { n =>
-          var jsObj = play.api.libs.json.Json.obj()
-          (0 to 10).foreach { n =>
-            jsObj += (n.toString -> JsNumber(n * n))
-          }
-        }
-      }
-
-      duration("map to json 2") {
-        (0 to 50) foreach { n =>
-          val numberMaps = (0 to 10).map { n => (n.toString -> JsNumber(n * n)) }.toMap
-          Json.toJson(numberMaps)
-        }
-      }
-
-      duration("directMakeJson 2") {
-        (0 to 50) foreach { n =>
-          var jsObj = play.api.libs.json.Json.obj()
-          (0 to 10).foreach { n =>
-            jsObj += (n.toString -> JsNumber(n * n))
-          }
+      duration("Append by Json.obj(newJson -> JsObj)") {
+        (0 to 100000) foreach { n =>
+          Json.obj(s"$n" -> numberJson)
         }
       }
       true
+    }
+  }
+
+  "Make Json" >> {
+    duration("map to json") {
+      (0 to 10000) foreach { n =>
+        val numberMaps = (0 to 100).map { n =>
+          n.toString -> JsNumber(n * n)
+        }.toMap
+
+        Json.toJson(numberMaps)
+      }
+    }
+
+    duration("direct") {
+      (0 to 10000) foreach { n =>
+        var jsObj = play.api.libs.json.Json.obj()
+
+        (0 to 100).foreach { n =>
+          jsObj += (n.toString -> JsNumber(n * n))
+        }
+      }
     }
     true
   }

--- a/s2core/src/test/scala/org/apache/s2graph/core/benchmark/SamplingBenchmarkSpec.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/benchmark/SamplingBenchmarkSpec.scala
@@ -1,102 +1,105 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package org.apache.s2graph.core.benchmark
-
-import scala.annotation.tailrec
-import scala.util.Random
-
-class SamplingBenchmarkSpec extends BenchmarkCommon {
-  "sample" should {
-
-    "sample benchmark" in {
-      @tailrec
-      def randomInt(n: Int, range: Int, set: Set[Int] = Set.empty[Int]): Set[Int] = {
-        if (set.size == n) set
-        else randomInt(n, range, set + Random.nextInt(range))
-      }
-
-      // sample using random array
-      def randomArraySample[T](num: Int, ls: List[T]): List[T] = {
-        val randomNum = randomInt(num, ls.size)
-        var sample = List.empty[T]
-        var idx = 0
-        ls.foreach { e =>
-          if (randomNum.contains(idx)) sample = e :: sample
-          idx += 1
-        }
-        sample
-      }
-
-      // sample using shuffle
-      def shuffleSample[T](num: Int, ls: List[T]): List[T] = {
-        Random.shuffle(ls).take(num)
-      }
-
-      // sample using random number generation
-      def rngSample[T](num: Int, ls: List[T]): List[T] = {
-        var sampled = List.empty[T]
-        val N = ls.size // population
-        var t = 0 // total input records dealt with
-        var m = 0 // number of items selected so far
-
-        while (m < num) {
-          val u = Random.nextDouble()
-          if ((N - t) * u < num - m) {
-            sampled = ls(t) :: sampled
-            m += 1
-          }
-          t += 1
-        }
-        sampled
-      }
-
-      // test data
-      val testLimit = 10000
-      val testNum = 10
-      val testData = (0 to 1000).toList
-
-      // dummy for warm-up
-      (0 to testLimit) foreach { n =>
-        randomArraySample(testNum, testData)
-        shuffleSample(testNum, testData)
-        rngSample(testNum, testData)
-      }
-
-      duration("Random Array Sampling") {
-        (0 to testLimit) foreach { _ =>
-          val sampled = randomArraySample(testNum, testData)
-        }
-      }
-
-      duration("Shuffle Sampling") {
-        (0 to testLimit) foreach { _ =>
-          val sampled = shuffleSample(testNum, testData)
-        }
-      }
-
-      duration("RNG Sampling") {
-        (0 to testLimit) foreach { _ =>
-          val sampled = rngSample(testNum, testData)
-        }
-      }
-      true
-    }
-  }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *   http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package org.apache.s2graph.rest.play.benchmark
+//
+//import play.api.test.{FakeApplication, PlaySpecification, WithApplication}
+//
+//import scala.annotation.tailrec
+//import scala.util.Random
+//
+//class SamplingBenchmarkSpec extends BenchmarkCommon with PlaySpecification {
+//  "sample" should {
+//    implicit val app = FakeApplication()
+//
+//    "sample benchmark" in new WithApplication(app) {
+//      @tailrec
+//      def randomInt(n: Int, range: Int, set: Set[Int] = Set.empty[Int]): Set[Int] = {
+//        if (set.size == n) set
+//        else randomInt(n, range, set + Random.nextInt(range))
+//      }
+//
+//      // sample using random array
+//      def randomArraySample[T](num: Int, ls: List[T]): List[T] = {
+//        val randomNum = randomInt(num, ls.size)
+//        var sample = List.empty[T]
+//        var idx = 0
+//        ls.foreach { e =>
+//          if (randomNum.contains(idx)) sample = e :: sample
+//          idx += 1
+//        }
+//        sample
+//      }
+//
+//      // sample using shuffle
+//      def shuffleSample[T](num: Int, ls: List[T]): List[T] = {
+//        Random.shuffle(ls).take(num)
+//      }
+//
+//      // sample using random number generation
+//      def rngSample[T](num: Int, ls: List[T]): List[T] = {
+//        var sampled = List.empty[T]
+//        val N = ls.size // population
+//        var t = 0 // total input records dealt with
+//        var m = 0 // number of items selected so far
+//
+//        while (m < num) {
+//          val u = Random.nextDouble()
+//          if ((N - t) * u < num - m) {
+//            sampled = ls(t) :: sampled
+//            m += 1
+//          }
+//          t += 1
+//        }
+//        sampled
+//      }
+//
+//      // test data
+//      val testLimit = 10000
+//      val testNum = 10
+//      val testData = (0 to 1000).toList
+//
+//      // dummy for warm-up
+//      (0 to testLimit) foreach { n =>
+//        randomArraySample(testNum, testData)
+//        shuffleSample(testNum, testData)
+//        rngSample(testNum, testData)
+//      }
+//
+//      duration("Random Array Sampling") {
+//        (0 to testLimit) foreach { _ =>
+//          val sampled = randomArraySample(testNum, testData)
+//        }
+//      }
+//
+//      duration("Shuffle Sampling") {
+//        (0 to testLimit) foreach { _ =>
+//          val sampled = shuffleSample(testNum, testData)
+//        }
+//      }
+//
+//      duration("RNG Sampling") {
+//        (0 to testLimit) foreach { _ =>
+//          val sampled = rngSample(testNum, testData)
+//        }
+//      }
+//      true
+//    }
+//  }
+//}

--- a/s2rest_play/app/org/apache/s2graph/rest/play/Bootstrap.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/Bootstrap.scala
@@ -52,7 +52,7 @@ object Global extends WithFilters(new GzipFilter()) {
     // init s2graph with config
     s2graph = new Graph(config)(ec)
     storageManagement = new Management(s2graph)
-    s2parser = new RequestParser(s2graph.config) // merged config
+    s2parser = new RequestParser(s2graph) 
     s2rest = new RestHandler(s2graph)(ec)
 
     logger.info(s"starts with num of thread: $numOfThread, ${threadPool.getClass.getSimpleName}")
@@ -83,7 +83,7 @@ object Global extends WithFilters(new GzipFilter()) {
     wallLogHandler.shutdown()
     QueueActor.shutdown()
 
-    /*
+    /**
      * shutdown hbase client for flush buffers.
      */
     shutdown()

--- a/s2rest_play/app/org/apache/s2graph/rest/play/config/Config.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/config/Config.scala
@@ -43,8 +43,12 @@ object Config {
   lazy val KAFKA_METADATA_BROKER_LIST = conf.getString("kafka.metadata.broker.list").getOrElse("localhost")
 
   lazy val KAFKA_LOG_TOPIC = s"s2graphIn${PHASE}"
+  lazy val KAFKA_LOG_TOPIC_JSON = s"s2graphIn${PHASE}Json"
   lazy val KAFKA_LOG_TOPIC_ASYNC = s"s2graphIn${PHASE}Async"
+  lazy val KAFKA_LOG_TOPIC_ASYNC_JSON = s"s2graphIn${PHASE}AsyncJson"
   lazy val KAFKA_FAIL_TOPIC = s"s2graphIn${PHASE}Failed"
+  lazy val KAFKA_FAIL_TOPIC_JSON = s"s2graphIn${PHASE}FailedJson"
+  lazy val KAFKA_MUTATE_FAIL_TOPIC = s"mutateFailed_${PHASE}"
 
   // is query or write
   lazy val IS_QUERY_SERVER = conf.getBoolean("is.query.server").getOrElse(true)

--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/ApplicationController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/ApplicationController.scala
@@ -22,10 +22,10 @@ package org.apache.s2graph.rest.play.controllers
 import akka.util.ByteString
 import org.apache.s2graph.core.GraphExceptions.BadQueryException
 import org.apache.s2graph.core.PostProcess
+import org.apache.s2graph.core.rest.RestHandler.CanLookup
 import org.apache.s2graph.core.utils.logger
 import org.apache.s2graph.rest.play.config.Config
 import play.api.http.HttpEntity
-import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.{JsString, JsValue}
 import play.api.mvc._
 
@@ -41,6 +41,10 @@ object ApplicationController extends Controller {
   val jsonParser: BodyParser[JsValue] = s2parse.json
 
   val jsonText: BodyParser[String] = s2parse.jsonText
+
+  implicit val oneTupleLookup = new CanLookup[Headers] {
+    override def lookup(m: Headers, key: String) = m.get(key)
+  }
 
   private def badQueryExceptionResults(ex: Exception) =
     Future.successful(BadRequest(PostProcess.badRequestResults(ex)).as(applicationJsonHeader))

--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/CounterController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/CounterController.scala
@@ -156,9 +156,11 @@ object CounterController extends Controller {
           useProfile = useProfile, bucketImpId, useRank = useRank, ttl, dailyTtl, Some(hbaseTable), intervalUnit,
           rateActionId, rateBaseId, rateThreshold)
 
-        // prepare exact storage
-        exactCounter(version).prepare(policy)
-        if (useRank) {
+        if (rateAction.isEmpty) {
+          // prepare exact storage
+          exactCounter(version).prepare(policy)
+        }
+        if (useRank || rateAction.isDefined) {
           // prepare ranking storage
           rankingCounter(version).prepare(policy)
         }
@@ -253,8 +255,11 @@ object CounterController extends Controller {
           // change table name
           val newTableName = Seq(tablePrefixMap(version), service, policy.ttl) ++ policy.dailyTtl mkString "_"
           val newPolicy = policy.copy(version = version, hbaseTable = Some(newTableName))
-          exactCounter(version).prepare(newPolicy)
-          if (newPolicy.useRank) {
+
+          if (newPolicy.rateActionId.isEmpty) {
+            exactCounter(version).prepare(newPolicy)
+          }
+          if (newPolicy.useRank || newPolicy.rateActionId.isDefined) {
             rankingCounter(version).prepare(newPolicy)
           }
           Ok(Json.toJson(Map("msg" -> s"prepare storage v$version $service/$action")))
@@ -272,8 +277,10 @@ object CounterController extends Controller {
         policy <- counterModel.findByServiceAction(service, action, useCache = false)
       } yield {
         Try {
-          exactCounter(policy.version).destroy(policy)
-          if (policy.useRank) {
+          if (policy.rateActionId.isEmpty) {
+            exactCounter(policy.version).destroy(policy)
+          }
+          if (policy.useRank || policy.rateActionId.isDefined) {
             rankingCounter(policy.version).destroy(policy)
           }
           counterModel.deleteServiceAction(policy)

--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/ExperimentController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/ExperimentController.scala
@@ -19,7 +19,6 @@
 
 package org.apache.s2graph.rest.play.controllers
 
-import org.apache.s2graph.core.mysqls.Experiment
 import org.apache.s2graph.core.rest.RestHandler
 import play.api.mvc._
 
@@ -30,10 +29,10 @@ object ExperimentController extends Controller {
 
   import ApplicationController._
 
+  def experiments() = experiment("", "", "")
   def experiment(accessToken: String, experimentName: String, uuid: String) = withHeaderAsync(jsonText) { request =>
     val body = request.body
-
-    val res = rest.doPost(request.uri, body, request.headers.get(Experiment.impressionKey))
+    val res = rest.doPost(request.uri, body, request.headers)
     res.body.map { case js =>
       val headers = res.headers :+ ("result_size" -> rest.calcSize(js).toString)
       jsonResponse(js, headers: _*)

--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/PublishController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/PublishController.scala
@@ -63,12 +63,4 @@ object PublishController extends Controller {
 
   def publish(topic: String) = publishOnly(topic)
 
-  //  def mutateBulk(topic: String) = Action.async(parse.text) { request =>
-  //    EdgeController.mutateAndPublish(Config.KAFKA_LOG_TOPIC, Config.KAFKA_FAIL_TOPIC, request.body).map { result =>
-  //      result.withHeaders(CONNECTION -> "Keep-Alive", "Keep-Alive" -> "timeout=10, max=10")
-  //    }
-  //  }
-  def mutateBulk(topic: String) = withHeaderAsync(parse.text) { request =>
-    EdgeController.mutateBulkFormat(request.body)
-  }
 }

--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/QueryController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/QueryController.scala
@@ -19,8 +19,6 @@
 
 package org.apache.s2graph.rest.play.controllers
 
-import org.apache.s2graph.core.JSONParser
-import org.apache.s2graph.core.mysqls.Experiment
 import org.apache.s2graph.core.rest.RestHandler
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -31,13 +29,11 @@ object QueryController extends Controller {
 
   import ApplicationController._
   import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
   private val rest: RestHandler = org.apache.s2graph.rest.play.Global.s2rest
 
   def delegate(request: Request[String]) = {
-    rest.doPost(request.uri, request.body, request.headers.get(Experiment.impressionKey)).body.map {
-      js =>
-        jsonResponse(js, "result_size" -> rest.calcSize(js).toString)
+    rest.doPost(request.uri, request.body, request.headers).body.map { js =>
+      jsonResponse(js, "result_size" -> rest.calcSize(js).toString)
     } recoverWith ApplicationController.requestFallback(request.body)
   }
 
@@ -58,13 +54,12 @@ object QueryController extends Controller {
   def getEdgesGroupedExcludedFormatted() = withHeaderAsync(jsonText)(delegate)
 
   def getEdge(srcId: String, tgtId: String, labelName: String, direction: String) =
-    withHeaderAsync(jsonText) {
-      request =>
-        val params = Json.arr(Json.obj("label" -> labelName, "direction" -> direction, "from" -> srcId, "to" -> tgtId))
-        rest.checkEdges(params).body.map {
-          js =>
-            jsonResponse(js, "result_size" -> rest.calcSize(js).toString)
-        } recoverWith ApplicationController.requestFallback(request.body)
+    withHeaderAsync(jsonText) { request =>
+      val params = Json.arr(Json.obj("label" -> labelName, "direction" -> direction, "from" -> srcId, "to" -> tgtId))
+      rest.checkEdges(params).body.map {
+        js =>
+          jsonResponse(js, "result_size" -> rest.calcSize(js).toString)
+      } recoverWith ApplicationController.requestFallback(request.body)
     }
 
   def getVertices() = withHeaderAsync(jsonText)(delegate)

--- a/s2rest_play/conf/reference.conf
+++ b/s2rest_play/conf/reference.conf
@@ -125,6 +125,7 @@ local.queue.actor.rate.limit=1000000
 # local retry number
 max.retry.number=100
 max.back.off=50
+back.off.timeout=1000
 delete.all.fetch.size=10000
 hbase.fail.prob=-1.0
 lock.expire.time=600000

--- a/s2rest_play/conf/routes
+++ b/s2rest_play/conf/routes
@@ -23,7 +23,7 @@
 
 
 # publish
-POST        /publish/:topic                                               org.apache.s2graph.rest.play.controllers.PublishController.mutateBulk(topic)
+#POST        /publish/:topic                                               org.apache.s2graph.rest.play.controllers.PublishController.mutateBulk(topic)
 POST        /publishOnly/:topic                                           org.apache.s2graph.rest.play.controllers.PublishController.publishOnly(topic)
 
 #### Health Check
@@ -37,6 +37,7 @@ POST        /graphs/edges/insertBulk                                      org.ap
 POST        /graphs/edges/delete                                          org.apache.s2graph.rest.play.controllers.EdgeController.deletes()
 POST        /graphs/edges/deleteWithWait                                  org.apache.s2graph.rest.play.controllers.EdgeController.deletesWithWait()
 POST        /graphs/edges/deleteAll                                       org.apache.s2graph.rest.play.controllers.EdgeController.deleteAll()
+POST        /graphs/edges/deleteAllWithOutWait                            org.apache.s2graph.rest.play.controllers.EdgeController.deleteAllWithOutWait()
 POST        /graphs/edges/update                                          org.apache.s2graph.rest.play.controllers.EdgeController.updates()
 POST        /graphs/edges/updateWithWait                                  org.apache.s2graph.rest.play.controllers.EdgeController.updatesWithWait()
 POST        /graphs/edges/increment                                       org.apache.s2graph.rest.play.controllers.EdgeController.increments()
@@ -81,7 +82,7 @@ GET         /graphs/getLabels/:serviceName                                org.ap
 POST        /graphs/createLabel                                           org.apache.s2graph.rest.play.controllers.AdminController.createLabel()
 POST        /graphs/addIndex                                              org.apache.s2graph.rest.play.controllers.AdminController.addIndex()
 GET         /graphs/getLabel/:labelName                                   org.apache.s2graph.rest.play.controllers.AdminController.getLabel(labelName)
-PUT         /graphs/deleteLabel/:labelName                                org.apache.s2graph.rest.play.controllers.AdminController.deleteLabel(labelName)
+PUT         /graphs/deleteLabelReally/:labelName                          org.apache.s2graph.rest.play.controllers.AdminController.deleteLabel(labelName)
 
 POST        /graphs/addProp/:labelName                                    org.apache.s2graph.rest.play.controllers.AdminController.addProp(labelName)
 POST        /graphs/createServiceColumn                                   org.apache.s2graph.rest.play.controllers.AdminController.createServiceColumn()
@@ -117,7 +118,7 @@ POST    /counter/v1/mget                                                org.apac
 
 # Experiment API
 POST        /graphs/experiment/:accessToken/:experimentName/:uuid         org.apache.s2graph.rest.play.controllers.ExperimentController.experiment(accessToken, experimentName, uuid)
-
+POST        /graphs/experiments                                           org.apache.s2graph.rest.play.controllers.ExperimentController.experiments()
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /images/*file                                                 controllers.Assets.at(path="/public/images", file)


### PR DESCRIPTION
- add StepResult to abstract traversal result.
- change GroupBy, OrderBy, FilterOut logic from PostProcess and refactor PostProcess to only perform formatting.