### PR TITLE
[S2GRAPH-135] Change the way LabelIndexOption is implemented and improve it

### DIFF
--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -70,7 +70,8 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val labelNames = Map(testLabelName -> testLabelNameCreate,
       testLabelName2 -> testLabelName2Create,
       testLabelNameV1 -> testLabelNameV1Create,
-      testLabelNameWeak -> testLabelNameWeakCreate)
+      testLabelNameWeak -> testLabelNameWeakCreate,
+      testLabelNameLabelIndex -> testLabelNameLabelIndexCreate)
 
     for {
       (labelName, create) <- labelNames
@@ -135,7 +136,7 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
       logger.info(s2Query.toString)
       val stepResult = Await.result(graph.getEdges(s2Query), HttpRequestWaitingTime)
       val result = PostProcess.toJson(Option(s2Query.jsonQuery))(graph, s2Query.queryOption, stepResult)
-//      val result = Await.result(graph.getEdges(s2Query).(PostProcess.toJson), HttpRequestWaitingTime)
+      //      val result = Await.result(graph.getEdges(s2Query).(PostProcess.toJson), HttpRequestWaitingTime)
       logger.debug(s"${Json.prettyPrint(result)}")
       result
     }
@@ -169,6 +170,7 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val testLabelName2 = "s2graph_label_test_2"
     val testLabelNameV1 = "s2graph_label_test_v1"
     val testLabelNameWeak = "s2graph_label_test_weak"
+    val testLabelNameLabelIndex = "s2graph_label_test_index"
     val testColumnName = "user_id_test"
     val testColumnType = "long"
     val testTgtColumnName = "item_id_test"
@@ -176,6 +178,12 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val newHTableName = "new-htable"
     val index1 = "idx_1"
     val index2 = "idx_2"
+    val idxStoreInDropDegree = "idx_drop_In"
+    val idxStoreOutDropDegree = "idx_drop_out"
+    val idxStoreIn = "idx_store_In"
+    val idxStoreOut = "idx_store_out"
+    val idxDropInStoreDegree = "idx_drop_in_store_degree"
+    val idxDropOutStoreDegree = "idx_drop_out_store_degree"
 
     val NumOfEachTest = 30
     val HttpRequestWaitingTime = Duration("60 seconds")
@@ -341,6 +349,53 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     "consistencyLevel": "weak",
     "isDirected": true,
     "compressionAlgorithm": "gz"
+  }"""
+
+    val testLabelNameLabelIndexCreate =
+      s"""
+  {
+    "label": "$testLabelNameLabelIndex",
+    "srcServiceName": "$testServiceName",
+    "srcColumnName": "$testColumnName",
+    "srcColumnType": "long",
+    "tgtServiceName": "$testServiceName",
+    "tgtColumnName": "$testColumnName",
+    "tgtColumnType": "long",
+    "indices": [
+       {"name": "$index1", "propNames": ["weight", "time", "is_hidden", "is_blocked"]},
+       {"name": "$idxStoreInDropDegree", "propNames": ["time"], "options": { "in": {"storeDegree": false }, "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreOutDropDegree", "propNames": ["weight"], "options": { "out": {"storeDegree": false}, "in": { "method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreIn", "propNames": ["is_hidden"], "options": { "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreOut", "propNames": ["weight", "is_blocked"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "normal" }}},
+       {"name": "$idxDropInStoreDegree", "propNames": ["is_blocked"], "options": { "in": {"method": "drop" }, "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxDropOutStoreDegree", "propNames": ["weight", "is_blocked", "_timestamp"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"}}}
+    ],
+    "props": [
+    {
+      "name": "time",
+      "dataType": "long",
+      "defaultValue": 0
+    },
+    {
+      "name": "weight",
+      "dataType": "long",
+      "defaultValue": 0
+    },
+    {
+      "name": "is_hidden",
+      "dataType": "boolean",
+      "defaultValue": false
+    },
+    {
+      "name": "is_blocked",
+      "dataType": "boolean",
+      "defaultValue": false
+    }
+    ],
+    "consistencyLevel": "strong",
+    "schemaVersion": "v4",
+    "compressionAlgorithm": "gz",
+    "hTableName": "$testHTableName"
   }"""
   }
 }

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/LabelIndexOptionTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/LabelIndexOptionTest.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.core.Integrate
+
+import org.apache.s2graph.core._
+import org.scalatest.BeforeAndAfterEach
+import play.api.libs.json._
+
+class LabelIndexOptionTest extends IntegrateCommon with BeforeAndAfterEach {
+
+  import TestUtil._
+
+  // called by start test, once
+  override def initTestData(): Unit = {
+    super.initTestData()
+
+    val insert = "insert"
+    val e = "e"
+    val weight = "weight"
+    val is_hidden = "is_hidden"
+
+    insertEdgesSync(
+      toEdge(1, insert, e, 0, 1, testLabelNameLabelIndex),
+      toEdge(1, insert, e, 0, 2, testLabelNameLabelIndex),
+      toEdge(1, insert, e, 0, 3, testLabelNameLabelIndex)
+    )
+  }
+
+  def getQuery(ids: Seq[Int], direction: String, indexName: String): Query =
+    Query(
+      vertices = ids.map(graph.toVertex(testServiceName, testColumnName, _)),
+      steps = Vector(
+        Step(Seq(QueryParam(testLabelNameLabelIndex, direction = direction, indexName = indexName)))
+      )
+    )
+
+  /**
+    * "indices": [
+    * {"name": "$index1", "propNames": ["weight", "time", "is_hidden", "is_blocked"]},
+    * {"name": "$idxStoreInDropDegree", "propNames": ["time"], "options": { "in": {"storeDegree": false }, "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreOutDropDegree", "propNames": ["weight"], "options": { "out": {"storeDegree": false}, "in": { "method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreIn", "propNames": ["is_hidden"], "options": { "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreOut", "propNames": ["weight", "is_blocked"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "normal" }}},
+    * {"name": "$idxDropInStoreDegree", "propNames": ["is_blocked"], "options": { "in": {"method": "drop" }, "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxDropOutStoreDegree", "propNames": ["weight", "is_blocked", "_timestamp"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"}}}
+    * ],
+    **/
+
+  /**
+    * index without no options
+    */
+  test("normal index should store in/out direction Edges with Degrees") {
+    var edges = getEdgesSync(getQuery(Seq(0), "out", index1))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+
+    edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", index1))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false } }
+    */
+  test("storeDegree: store out direction Edge and drop Degree") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreOutDropDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "in": { "method": "drop", "storeDegree": false } }
+    */
+  test("storeDegree: store in direction Edge and drop Degree") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreInDropDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false } }
+    */
+  test("index for in direction should drop out direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreIn))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  test("index for in direction should store in direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreIn))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "in": {"method": "drop", "storeDegree": false } }
+    */
+  test("index for out direction should store out direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreOut))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  test("index for out direction should drop in direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreOut))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false} }
+    */
+  test("index for in direction should drop in direction edge and store degree") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxDropInStoreDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"} }
+    */
+  test("index for out direction should drop out direction edge and store degree") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxDropOutStoreDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+}


### PR DESCRIPTION
I changed the functionality of 'labelIndexOption' as described in {{S2GRAPH-135}} issue.

When this PR is merged, you can set different options for each direction(in, out) through the 'options' field in 'LabelIndex' table.