### PR TITLE
[S2GRAPH-132] Added the ability to buffer write rpc for increment requests.

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/mysqls/LabelIndex.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/mysqls/LabelIndex.scala
@@ -20,7 +20,7 @@
 package org.apache.s2graph.core.mysqls
 
 import org.apache.s2graph.core.GraphUtil
-import org.apache.s2graph.core.mysqls.LabelIndex.WriteOption
+import org.apache.s2graph.core.mysqls.LabelIndex.indexOption
 import org.apache.s2graph.core.utils.logger
 import play.api.libs.json.{JsObject, JsString, Json}
 import scalikejdbc._
@@ -42,7 +42,7 @@ object LabelIndex extends Model[LabelIndex] {
     )
   }
 
-  case class WriteOption(dir: Byte,
+  case class indexOption(dir: Byte,
                          method: String,
                          rate: Double,
                          totalModular: Long,
@@ -191,7 +191,7 @@ case class LabelIndex(id: Option[Int], labelId: Int, name: String, seq: Byte, me
     )
   }
 
-  def parseOption(dir: String): Option[WriteOption] = try {
+  def parseOption(dir: String): Option[indexOption] = try {
     options.map { string =>
       val jsObj = Json.parse(string) \ dir
 
@@ -200,7 +200,7 @@ case class LabelIndex(id: Option[Int], labelId: Int, name: String, seq: Byte, me
       val totalModular = (jsObj \ "totalModular").asOpt[Long].getOrElse(100L)
       val storeDegree = (jsObj \ "storeDegree").asOpt[Boolean].getOrElse(true)
 
-      WriteOption(GraphUtil.directions(dir).toByte, method, rate, totalModular, storeDegree)
+      indexOption(GraphUtil.directions(dir).toByte, method, rate, totalModular, storeDegree)
     }
   } catch {
     case e: Exception =>

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/Storage.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/Storage.scala
@@ -362,9 +362,11 @@ abstract class Storage[Q, R](val graph: S2Graph,
       val futures = edges.map { edge =>
         val (_, edgeUpdate) = S2Edge.buildOperation(None, Seq(edge))
 
+        val (bufferIncr, nonBufferIncr) = increments(edgeUpdate.deepCopy)
         val mutations =
-          indexedEdgeMutations(edgeUpdate) ++ snapshotEdgeMutations(edgeUpdate) ++ increments(edgeUpdate)
+          indexedEdgeMutations(edgeUpdate.deepCopy) ++ snapshotEdgeMutations(edgeUpdate.deepCopy) ++ nonBufferIncr
 
+        if (bufferIncr.nonEmpty) writeToStorage(zkQuorum, bufferIncr, withWait = false)
 
         writeToStorage(zkQuorum, mutations, withWait)
       }
@@ -764,8 +766,10 @@ abstract class Storage[Q, R](val graph: S2Graph,
       val p = Random.nextDouble()
       if (p < FailProb) Future.failed(new PartialFailureException(squashedEdge, 2, s"$p"))
       else {
-        val incrs = increments(edgeMutate)
-        _write(incrs, true)
+        val (bufferIncr, nonBufferIncr) = increments(edgeMutate.deepCopy)
+
+        if (bufferIncr.nonEmpty) _write(bufferIncr, withWait = false)
+        _write(nonBufferIncr, withWait = true)
       }
     }
   }
@@ -1037,23 +1041,25 @@ abstract class Storage[Q, R](val graph: S2Graph,
   def snapshotEdgeMutations(edgeMutate: EdgeMutate): Seq[SKeyValue] =
     edgeMutate.newSnapshotEdge.map(e => snapshotEdgeSerializer(e).toKeyValues.map(_.copy(durability = e.label.durability))).getOrElse(Nil)
 
-  def increments(edgeMutate: EdgeMutate): Seq[SKeyValue] = {
+  def increments(edgeMutate: EdgeMutate): (Seq[SKeyValue], Seq[SKeyValue]) = {
     (edgeMutate.edgesToDeleteWithIndexOptForDegree.isEmpty, edgeMutate.edgesToInsertWithIndexOptForDegree.isEmpty) match {
       case (true, true) =>
         /** when there is no need to update. shouldUpdate == false */
-        Nil
+        Nil -> Nil
 
       case (true, false) =>
         /** no edges to delete but there is new edges to insert so increase degree by 1 */
-        edgeMutate.edgesToInsertWithIndexOptForDegree.flatMap(buildIncrementsAsync(_))
+        val (buffer, nonBuffer) = EdgeMutate.partitionBufferedIncrement(edgeMutate.edgesToInsertWithIndexOptForDegree)
+        buffer.flatMap(buildIncrementsAsync(_)) -> nonBuffer.flatMap(buildIncrementsAsync(_))
 
       case (false, true) =>
         /** no edges to insert but there is old edges to delete so decrease degree by 1 */
-        edgeMutate.edgesToDeleteWithIndexOptForDegree.flatMap(buildIncrementsAsync(_, -1))
+        val (buffer, nonBuffer) = EdgeMutate.partitionBufferedIncrement(edgeMutate.edgesToDeleteWithIndexOptForDegree)
+        buffer.flatMap(buildIncrementsAsync(_, -1)) -> nonBuffer.flatMap(buildIncrementsAsync(_, -1))
 
       case (false, false) =>
         /** update on existing edges so no change on degree */
-        Nil
+        Nil -> Nil
     }
   }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/hbase/AsynchbaseStorage.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/hbase/AsynchbaseStorage.scala
@@ -432,7 +432,7 @@ class AsynchbaseStorage(override val graph: S2Graph,
     } yield {
         val futures: List[Deferred[(Boolean, Long, Long)]] = for {
           relEdge <- edge.relatedEdges
-          edgeWithIndex <- relEdge.edgesWithIndexValid
+          edgeWithIndex <- EdgeMutate.filterIndexOption(relEdge.edgesWithIndexValid)
         } yield {
           val countWithTs = edge.propertyValueInner(LabelMeta.count)
           val countVal = countWithTs.innerVal.toString().toLong

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -70,7 +70,8 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val labelNames = Map(testLabelName -> testLabelNameCreate,
       testLabelName2 -> testLabelName2Create,
       testLabelNameV1 -> testLabelNameV1Create,
-      testLabelNameWeak -> testLabelNameWeakCreate)
+      testLabelNameWeak -> testLabelNameWeakCreate,
+      testLabelNameLabelIndex -> testLabelNameLabelIndexCreate)
 
     for {
       (labelName, create) <- labelNames
@@ -135,7 +136,7 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
       logger.info(s2Query.toString)
       val stepResult = Await.result(graph.getEdges(s2Query), HttpRequestWaitingTime)
       val result = PostProcess.toJson(Option(s2Query.jsonQuery))(graph, s2Query.queryOption, stepResult)
-//      val result = Await.result(graph.getEdges(s2Query).(PostProcess.toJson), HttpRequestWaitingTime)
+      //      val result = Await.result(graph.getEdges(s2Query).(PostProcess.toJson), HttpRequestWaitingTime)
       logger.debug(s"${Json.prettyPrint(result)}")
       result
     }
@@ -169,6 +170,7 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val testLabelName2 = "s2graph_label_test_2"
     val testLabelNameV1 = "s2graph_label_test_v1"
     val testLabelNameWeak = "s2graph_label_test_weak"
+    val testLabelNameLabelIndex = "s2graph_label_test_index"
     val testColumnName = "user_id_test"
     val testColumnType = "long"
     val testTgtColumnName = "item_id_test"
@@ -176,6 +178,12 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     val newHTableName = "new-htable"
     val index1 = "idx_1"
     val index2 = "idx_2"
+    val idxStoreInDropDegree = "idx_drop_In"
+    val idxStoreOutDropDegree = "idx_drop_out"
+    val idxStoreIn = "idx_store_In"
+    val idxStoreOut = "idx_store_out"
+    val idxDropInStoreDegree = "idx_drop_in_store_degree"
+    val idxDropOutStoreDegree = "idx_drop_out_store_degree"
 
     val NumOfEachTest = 30
     val HttpRequestWaitingTime = Duration("60 seconds")
@@ -341,6 +349,53 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
     "consistencyLevel": "weak",
     "isDirected": true,
     "compressionAlgorithm": "gz"
+  }"""
+
+    val testLabelNameLabelIndexCreate =
+      s"""
+  {
+    "label": "$testLabelNameLabelIndex",
+    "srcServiceName": "$testServiceName",
+    "srcColumnName": "$testColumnName",
+    "srcColumnType": "long",
+    "tgtServiceName": "$testServiceName",
+    "tgtColumnName": "$testColumnName",
+    "tgtColumnType": "long",
+    "indices": [
+       {"name": "$index1", "propNames": ["weight", "time", "is_hidden", "is_blocked"]},
+       {"name": "$idxStoreInDropDegree", "propNames": ["time"], "options": { "in": {"storeDegree": false }, "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreOutDropDegree", "propNames": ["weight"], "options": { "out": {"storeDegree": false}, "in": { "method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreIn", "propNames": ["is_hidden"], "options": { "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxStoreOut", "propNames": ["weight", "is_blocked"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "normal" }}},
+       {"name": "$idxDropInStoreDegree", "propNames": ["is_blocked"], "options": { "in": {"method": "drop" }, "out": {"method": "drop", "storeDegree": false }}},
+       {"name": "$idxDropOutStoreDegree", "propNames": ["weight", "is_blocked", "_timestamp"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"}}}
+    ],
+    "props": [
+    {
+      "name": "time",
+      "dataType": "long",
+      "defaultValue": 0
+    },
+    {
+      "name": "weight",
+      "dataType": "long",
+      "defaultValue": 0
+    },
+    {
+      "name": "is_hidden",
+      "dataType": "boolean",
+      "defaultValue": false
+    },
+    {
+      "name": "is_blocked",
+      "dataType": "boolean",
+      "defaultValue": false
+    }
+    ],
+    "consistencyLevel": "strong",
+    "schemaVersion": "v4",
+    "compressionAlgorithm": "gz",
+    "hTableName": "$testHTableName"
   }"""
   }
 }

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/LabelIndexOptionTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/LabelIndexOptionTest.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.core.Integrate
+
+import org.apache.s2graph.core._
+import org.scalatest.BeforeAndAfterEach
+import play.api.libs.json._
+
+class LabelIndexOptionTest extends IntegrateCommon with BeforeAndAfterEach {
+
+  import TestUtil._
+
+  // called by start test, once
+  override def initTestData(): Unit = {
+    super.initTestData()
+
+    val insert = "insert"
+    val e = "e"
+    val weight = "weight"
+    val is_hidden = "is_hidden"
+
+    insertEdgesSync(
+      toEdge(1, insert, e, 0, 1, testLabelNameLabelIndex),
+      toEdge(1, insert, e, 0, 2, testLabelNameLabelIndex),
+      toEdge(1, insert, e, 0, 3, testLabelNameLabelIndex)
+    )
+  }
+
+  def getQuery(ids: Seq[Int], direction: String, indexName: String): Query =
+    Query(
+      vertices = ids.map(graph.toVertex(testServiceName, testColumnName, _)),
+      steps = Vector(
+        Step(Seq(QueryParam(testLabelNameLabelIndex, direction = direction, indexName = indexName)))
+      )
+    )
+
+  /**
+    * "indices": [
+    * {"name": "$index1", "propNames": ["weight", "time", "is_hidden", "is_blocked"]},
+    * {"name": "$idxStoreInDropDegree", "propNames": ["time"], "options": { "in": {"storeDegree": false }, "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreOutDropDegree", "propNames": ["weight"], "options": { "out": {"storeDegree": false}, "in": { "method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreIn", "propNames": ["is_hidden"], "options": { "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxStoreOut", "propNames": ["weight", "is_blocked"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "normal" }}},
+    * {"name": "$idxDropInStoreDegree", "propNames": ["is_blocked"], "options": { "in": {"method": "drop" }, "out": {"method": "drop", "storeDegree": false }}},
+    * {"name": "$idxDropOutStoreDegree", "propNames": ["weight", "is_blocked", "_timestamp"], "options": { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"}}}
+    * ],
+    **/
+
+  /**
+    * index without no options
+    */
+  test("normal index should store in/out direction Edges with Degrees") {
+    var edges = getEdgesSync(getQuery(Seq(0), "out", index1))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+
+    edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", index1))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false } }
+    */
+  test("storeDegree: store out direction Edge and drop Degree") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreOutDropDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "in": { "method": "drop", "storeDegree": false } }
+    */
+  test("storeDegree: store in direction Edge and drop Degree") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreInDropDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false } }
+    */
+  test("index for in direction should drop out direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreIn))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  test("index for in direction should store in direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreIn))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "in": {"method": "drop", "storeDegree": false } }
+    */
+  test("index for out direction should store out direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxStoreOut))
+    (edges \ "results").as[Seq[JsValue]].size should be(3)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  test("index for out direction should drop in direction edge") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxStoreOut))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(0)
+  }
+
+  /**
+    * { "out": {"method": "drop", "storeDegree": false} }
+    */
+  test("index for in direction should drop in direction edge and store degree") {
+    val edges = getEdgesSync(getQuery(Seq(1, 2, 3), "in", idxDropInStoreDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+
+  /**
+    * { "in": {"method": "drop", "storeDegree": false }, "out": {"method": "drop"} }
+    */
+  test("index for out direction should drop out direction edge and store degree") {
+    val edges = getEdgesSync(getQuery(Seq(0), "out", idxDropOutStoreDegree))
+    (edges \ "results").as[Seq[JsValue]].size should be(0)
+    (edges \\ "_degree").map(_.as[Long]).sum should be(3)
+  }
+}


### PR DESCRIPTION
This feature will reduce the number of RPCs delivered to each region and will therefore improve increment performance.

I've discovered a few issues while adding this feature.

The data on the Edge has changed where i did not expected it.

It appears that the Edge class has been changed to a mutable.

To solve this problem, I used a deepCopied of the Edge where i created the RPC

I would like to discuss this in another thread to find a more fundamental cause.


