### PR TITLE
[S2GRAPH-168]:Fix args order mismatch when use addServiceColumnProp

### DIFF
--- a/s2rest_play/app/org/apache/s2graph/rest/play/controllers/AdminController.scala
+++ b/s2rest_play/app/org/apache/s2graph/rest/play/controllers/AdminController.scala
@@ -317,7 +317,7 @@ object AdminController extends Controller {
       serviceColumn <- ServiceColumn.find(service.id.get, columnName)
       prop <- requestParser.toPropElements(js).toOption
     } yield {
-      ColumnMeta.findOrInsert(serviceColumn.id.get, prop.name, prop.defaultValue)
+      ColumnMeta.findOrInsert(serviceColumn.id.get, prop.name, prop.datatType)
     }
   }
 


### PR DESCRIPTION
S2GRAPH-168 - Fix args order mismatch when use addServiceColumnProp