### PR TITLE
[S2GRAPH-184]: fix spark driver exit abnormally bug

### DIFF
--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/loader/GraphFileGenerator.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/loader/GraphFileGenerator.scala
@@ -38,6 +38,6 @@ object GraphFileGenerator {
       case "SPARK" => HFileGenerator.generate(sc, s2Config, input, options)
       case _ => throw new IllegalArgumentException("only supported type is MR/SPARK.")
     }
-    System.exit(0)
+    sc.stop()
   }
 }


### PR DESCRIPTION
Spark driver exit abnormally  and yarn would retry 3 times in s2jobs class  org.apache.s2graph.s2jobs.loader.GraphFileGenerator. Driver report ：
 
ApplicationMaster: Final app status: FAILED, exitCode: 16, (reason: Shutdown hook called before final status was reported.)

 

Which cause by  System.exit(0) in GraphFileGenerator.scala before sc.stop() was called.

fix https://issues.apache.org/jira/browse/S2GRAPH-184