### PR TITLE
[S2GRAPH-186]: fix wrong escaping of double quotation marks

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
@@ -582,12 +582,12 @@ class RequestParser(graph: S2GraphLike) {
   }
 
   def toVertex(jsValue: JsValue, operation: String, serviceName: Option[String] = None, columnName: Option[String] = None): S2VertexLike = {
-    val id = parse[JsValue](jsValue, "id")
+    val id = parse[String](jsValue, "id")
     val ts = parseOption[Long](jsValue, "timestamp").getOrElse(System.currentTimeMillis())
     val sName = if (serviceName.isEmpty) parse[String](jsValue, "serviceName") else serviceName.get
     val cName = if (columnName.isEmpty) parse[String](jsValue, "columnName") else columnName.get
     val props = fromJsonToProperties((jsValue \ "props").asOpt[JsObject].getOrElse(Json.obj()))
-    graph.toVertex(sName, cName, id.toString, props, ts, operation)
+    graph.toVertex(sName, cName, id, props, ts, operation)
   }
 
   def toPropElements(jsObj: JsValue) = Try {

--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
@@ -31,8 +31,7 @@ import org.apache.s2graph.core.parsers.{Where, WhereParser}
 import org.apache.s2graph.core.types._
 import play.api.libs.json._
 
-
-import scala.util.{Random, Failure, Success, Try}
+import scala.util.{Failure, Random, Success, Try}
 
 object TemplateHelper {
   val findVar = """\"?\$\{(.*?)\}\"?""".r
@@ -350,16 +349,23 @@ class RequestParser(graph: S2GraphLike) {
     )
   }
 
+  def extractVertexIds(jsValue: JsValue,
+                       serviceNameOpt: Option[String] = None,
+                       columnNameOpt: Option[String] = None): Seq[VertexId] = {
+    for {
+      value <- (jsValue \ "srcVertices").asOpt[Seq[JsValue]].getOrElse(Nil)
+      serviceName <- serviceNameOpt.orElse((value \ "serviceName").asOpt[String]).toSeq
+      columnName <- columnNameOpt.orElse((value \ "columnName").asOpt[String]).toSeq
+      idJson = (value \ "id").asOpt[JsValue].map(Seq(_)).getOrElse(Nil)
+      idsJson = (value \ "ids").asOpt[Seq[JsValue]].getOrElse(Nil)
+      id <- (idJson ++ idsJson).flatMap(jsValueToAny(_).toSeq).distinct
+    } yield graph.elementBuilder.newVertexId(serviceName)(columnName)(id)
+  }
+
   def toQuery(jsValue: JsValue, impIdOpt: Option[String]): Query = {
     try {
-      val vertices = for {
-        value <- (jsValue \ "srcVertices").asOpt[Seq[JsValue]].getOrElse(Nil)
-        serviceName <- (value \ "serviceName").asOpt[String].toSeq
-        columnName <- (value \ "columnName").asOpt[String].toSeq
-        idJson = (value \ "id").asOpt[JsValue].map(Seq(_)).getOrElse(Nil)
-        idsJson = (value \ "ids").asOpt[Seq[JsValue]].getOrElse(Nil)
-        id <- (idJson ++ idsJson).flatMap(jsValueToAny(_).toSeq).distinct
-      } yield graph.toVertex(serviceName, columnName, id)
+      val vertexIds = extractVertexIds(jsValue)
+      val vertices = vertexIds.map(vid => graph.elementBuilder.newVertex(vid))
 
       if (vertices.isEmpty) throw BadQueryException("srcVertices`s id is empty")
       val steps = parse[Vector[JsValue]](jsValue, "steps")
@@ -578,22 +584,18 @@ class RequestParser(graph: S2GraphLike) {
   }
 
   def toVertices(jsValue: JsValue, operation: String, serviceName: Option[String] = None, columnName: Option[String] = None) = {
-    toJsValues(jsValue).map(toVertex(_, operation, serviceName, columnName))
+    toJsValues(jsValue).flatMap(toVertex(_, operation, serviceName, columnName))
   }
 
-  def toVertex(jsValue: JsValue, operation: String, serviceName: Option[String] = None, columnName: Option[String] = None): S2VertexLike = {
-    var id:String = ""
-    try {
-        id = parse[String](jsValue, "id")
-    } catch {
-        case e:Exception=>
-        id = parse[JsValue](jsValue, "id").toString
+  def toVertex(jsValue: JsValue, operation: String, serviceName: Option[String] = None, columnName: Option[String] = None): Seq[S2VertexLike] = {
+    extractVertexIds(jsValue,
+      serviceNameOpt = serviceName,
+      columnNameOpt = columnName).map { vertexId =>
+      val ts = parseOption[Long](jsValue, "timestamp").getOrElse(System.currentTimeMillis())
+      val props = fromJsonToProperties((jsValue \ "props").asOpt[JsObject].getOrElse(Json.obj()))
+
+      graph.elementBuilder.toVertexInner(vertexId, props, ts, operation)
     }
-    val ts = parseOption[Long](jsValue, "timestamp").getOrElse(System.currentTimeMillis())
-    val sName = if (serviceName.isEmpty) parse[String](jsValue, "serviceName") else serviceName.get
-    val cName = if (columnName.isEmpty) parse[String](jsValue, "columnName") else columnName.get
-    val props = fromJsonToProperties((jsValue \ "props").asOpt[JsObject].getOrElse(Json.obj()))
-    graph.toVertex(sName, cName, id, props, ts, operation)
   }
 
   def toPropElements(jsObj: JsValue) = Try {

--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
@@ -582,7 +582,13 @@ class RequestParser(graph: S2GraphLike) {
   }
 
   def toVertex(jsValue: JsValue, operation: String, serviceName: Option[String] = None, columnName: Option[String] = None): S2VertexLike = {
-    val id = parse[String](jsValue, "id")
+    var id:String = ""
+    try {
+        id = parse[String](jsValue, "id")
+    } catch {
+        case e:Exception=>
+        id = parse[JsValue](jsValue, "id").toString
+    }
     val ts = parseOption[Long](jsValue, "timestamp").getOrElse(System.currentTimeMillis())
     val sName = if (serviceName.isEmpty) parse[String](jsValue, "serviceName") else serviceName.get
     val cName = if (columnName.isEmpty) parse[String](jsValue, "columnName") else columnName.get


### PR DESCRIPTION
1,create service 

curl -XPOST localhost:9000/graphs/createServiceColumn -H 'Content-Type: Application/json' -d '

{ "serviceName": "testApi", "columnName": "stringCn", "columnType": "string", "props": [] }
'

2, insert vertices

curl -XPOST localhost:9000/graphs/vertices/insert/testApi/stringCn -H 'Content-Type: Application/json' -d '
[
{"id":"a","props":{},"timestamp":1517616431}
]
'

3, query without escaping 
curl -XPOST localhost:9000/graphs/getVertices -H 'Content-Type: Application/json' -d '
[

{"serviceName": "testApi", "columnName": "stringCn", "ids": ["a"]}
]
'

4, howerver, query with double quotation marks
curl -XPOST localhost:9000/graphs/getVertices -H 'Content-Type: Application/json' -d '
[

{"serviceName": "testApi", "columnName": "stringCn", "ids": ["\\"a\\""]}
]
'

result

[{"serviceName":"testApi","columnName":"stringCn","id":"\"a\"","props":

{"lastModifiedAt":1517616431,"_timestamp":1517616431}
,"timestamp":1517616431}]

5， After fix
curl -XPOST localhost:9000/graphs/getVertices -H 'Content-Type: Application/json' -d '
[
{"serviceName": "testApi", "columnName": "stringCn", "ids": ["a"]}
]
'
[{"serviceName":"testApi","columnName":"stringCn","id":"a","props":{"lastModifiedAt":1517616431,"_timestamp":1517616431},"timestamp":1517616431}]


fix https://issues.apache.org/jira/browse/S2GRAPH-186