### PR TITLE
[S2GRAPH-187]: Make toQuery use toVertex to parse vertex from query JSON on RequestParser

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
@@ -578,7 +578,8 @@ class RequestParser(graph: S2GraphLike) {
   }
 
   def toVertex(jsValue: JsValue, operation: String = "insert", serviceName: Option[String] = None, columnName: Option[String] = None): Seq[S2VertexLike] = {
-    ((jsValue \ "id").asOpt[JsValue].map(Seq(_)).getOrElse(Nil) ++ (jsValue \ "ids").asOpt[Seq[JsValue]].getOrElse(Nil)).flatMap(JSONParser.jsValueToAny).map { id =>
+    ((jsValue \ "id").asOpt[JsValue].map(Seq(_)).getOrElse(Nil) ++
+      (jsValue \ "ids").asOpt[Seq[JsValue]].getOrElse(Nil)).flatMap(JSONParser.jsValueToAny).map { id =>
       val ts = parseOption[Long](jsValue, "timestamp").getOrElse(System.currentTimeMillis())
       val sName = if (serviceName.isEmpty) parse[String](jsValue, "serviceName") else serviceName.get
       val cName = if (columnName.isEmpty) parse[String](jsValue, "columnName") else columnName.get

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/IntegrateCommon.scala
@@ -96,11 +96,11 @@ trait IntegrateCommon extends FunSuite with Matchers with BeforeAndAfterAll {
       ("age", "integer", "0"),
       ("im", "string", "-")
     )
-
-    vertexPropsKeys.map { case (key, keyType, defaultValue) =>
-      Management.addVertexProp(testServiceName, testColumnName, key, keyType, defaultValue, storeInGlobalIndex = true)
+    Seq(testColumnName, testTgtColumnName).foreach { columnName =>
+      vertexPropsKeys.map { case (key, keyType, defaultValue) =>
+        Management.addVertexProp(testServiceName, columnName, key, keyType, defaultValue, storeInGlobalIndex = true)
+      }
     }
-
     // vertex type global index.
 //    val globalVertexIndex = management.buildGlobalIndex(GlobalIndex.VertexType, "test_age_index", Seq("age"))
 


### PR DESCRIPTION
- refactor `toVertex` to be shared on `toQuery`.
- add a test case on VertexTestHelper(escaping of double quotation marks).