### PR TITLE
[S2GRAPH-185] Support Spark Structured Streaming

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -29,7 +29,7 @@ object Common {
   val hadoopVersion = "2.7.3"
   val tinkerpopVersion = "3.2.5"
 
-  val elastic4sVersion = "6.1.0"
+  val elastic4sVersion = "6.1.1"
 
   /** use Log4j 1.2.17 as the SLF4j backend in runtime, with bridging libraries to forward JCL and JUL logs to SLF4j */
   val loggingRuntime = Seq(

--- a/s2jobs/build.sbt
+++ b/s2jobs/build.sbt
@@ -35,7 +35,9 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % specs2Version % "test",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "org.apache.hadoop" % "hadoop-distcp" % hadoopVersion,
-  "com.github.scopt" %% "scopt" % "3.7.0"
+  "org.elasticsearch" % "elasticsearch-spark-20_2.11" % elastic4sVersion,
+  "com.github.scopt" %% "scopt" % "3.7.0",
+  "com.holdenkarau" %% "spark-testing-base" % "2.3.0_0.9.0" % Test
 )
 
 crossScalaVersions := Seq("2.10.6")

--- a/s2jobs/build.sbt
+++ b/s2jobs/build.sbt
@@ -42,15 +42,19 @@ libraryDependencies ++= Seq(
 
 crossScalaVersions := Seq("2.10.6")
 
-mergeStrategy in assembly := {
+assemblyMergeStrategy in assembly := {
   case PathList("META-INF", ps @ _*) => MergeStrategy.discard
   case _ => MergeStrategy.first
 }
 
-excludedJars in assembly := {
+assemblyExcludedJars in assembly := {
   val cp = (fullClasspath in assembly).value
   cp filter {_.data.getName == "guava-16.0.1.jar"}
 }
+
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("com.google.protobuf.**" -> "org.apache.s2graph.shade.google.protobuf.@1").inAll
+)
 
 test in assembly := {}
 

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Job.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Job.scala
@@ -1,0 +1,49 @@
+package org.apache.s2graph.s2jobs
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.s2graph.s2jobs.task._
+
+import scala.collection.mutable
+
+class Job(ss:SparkSession, jobDesc:JobDescription) extends Serializable with Logger {
+  private val dfMap = mutable.Map[String, DataFrame]()
+
+  def run() = {
+    // source
+    jobDesc.sources.foreach{ source => dfMap.put(source.conf.name, source.toDF(ss))}
+    logger.debug(s"valid source DF set : ${dfMap.keySet}")
+
+    // process
+    var processRst:Seq[(String, DataFrame)] = Nil
+    do {
+      processRst = getValidProcess(jobDesc.processes)
+      processRst.foreach { case (name, df) => dfMap.put(name, df)}
+
+    } while(processRst.nonEmpty)
+
+    logger.debug(s"valid named DF set : ${dfMap.keySet}")
+    // sinks
+    jobDesc.sinks.foreach { s =>
+      val inputDFs = s.conf.inputs.flatMap{ input => dfMap.get(input)}
+      if (inputDFs.isEmpty) throw new IllegalArgumentException(s"sink has not valid inputs (${s.conf.name})")
+
+      // use only first input
+      s.write(inputDFs.head)
+    }
+
+  }
+
+  private def getValidProcess(processes:Seq[Process]):Seq[(String, DataFrame)] = {
+    val dfKeys = dfMap.keySet
+
+    processes.filter{ p =>
+        var existAllInput = true
+        p.conf.inputs.foreach { input => existAllInput = dfKeys(input) }
+        !dfKeys(p.conf.name) && existAllInput
+    }
+    .map { p =>
+      val inputMap = p.conf.inputs.map{ input => (input,  dfMap(input)) }.toMap
+      p.conf.name -> p.execute(ss, inputMap)
+    }
+  }
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Job.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Job.scala
@@ -22,6 +22,7 @@ class Job(ss:SparkSession, jobDesc:JobDescription) extends Serializable with Log
     } while(processRst.nonEmpty)
 
     logger.debug(s"valid named DF set : ${dfMap.keySet}")
+
     // sinks
     jobDesc.sinks.foreach { s =>
       val inputDFs = s.conf.inputs.flatMap{ input => dfMap.get(input)}
@@ -30,7 +31,8 @@ class Job(ss:SparkSession, jobDesc:JobDescription) extends Serializable with Log
       // use only first input
       s.write(inputDFs.head)
     }
-
+    // if stream query exist
+    if (ss.streams.active.length > 0) ss.streams.awaitAnyTermination()
   }
 
   private def getValidProcess(processes:Seq[Process]):Seq[(String, DataFrame)] = {

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobDescription.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobDescription.scala
@@ -1,0 +1,69 @@
+package org.apache.s2graph.s2jobs
+
+import play.api.libs.json.{JsValue, Json}
+import org.apache.s2graph.s2jobs.task._
+
+case class JobDescription(
+                           name:String,
+                           sources:Seq[Source],
+                           processes:Seq[task.Process],
+                           sinks:Seq[Sink]
+                         )
+
+object JobDescription extends Logger {
+  val dummy = JobDescription("dummy", Nil, Nil, Nil)
+
+  def apply(jsVal:JsValue):JobDescription = {
+    implicit val TaskConfReader = Json.reads[TaskConf]
+
+    logger.debug(s"JobDescription: ${jsVal}")
+
+    val jobName = (jsVal \ "name").as[String]
+    val sources = (jsVal \ "source").asOpt[Seq[TaskConf]].getOrElse(Nil).map(conf => getSource(conf))
+    val processes = (jsVal \ "process").asOpt[Seq[TaskConf]].getOrElse(Nil).map(conf => getProcess(conf))
+    val sinks = (jsVal \ "sink").asOpt[Seq[TaskConf]].getOrElse(Nil).map(conf => getSink(jobName, conf))
+
+    JobDescription(jobName, sources, processes, sinks)
+  }
+
+  def getSource(conf:TaskConf):Source = {
+    conf.`type` match {
+      case "kafka" => new KafkaSource(conf)
+      case "file"  => new FileSource(conf)
+      case "hive" => new HiveSource(conf)
+      case _ => throw new IllegalArgumentException(s"unsupported source type : ${conf.`type`}")
+    }
+  }
+
+  def getProcess(conf:TaskConf): task.Process = {
+    conf.`type` match {
+      case "sql" => new SqlProcess(conf)
+      case "custom" =>
+        val customClassOpt = conf.options.get("class")
+        customClassOpt match {
+          case Some(customClass:String) =>
+            logger.debug(s"custom class init.. $customClass")
+
+            Class.forName(customClass)
+              .getConstructor(TaskConf.getClass)
+              .newInstance(conf)
+              .asInstanceOf[task.Process]
+
+          case None => throw new IllegalArgumentException(s"custom class name is not exist.. ${conf}")
+        }
+
+      case _ => throw new IllegalArgumentException(s"unsupported process type : ${conf.`type`}")
+    }
+  }
+
+  def getSink(jobName:String, conf:TaskConf):Sink = {
+    conf.`type` match {
+      case "kafka" => new KafkaSink(jobName, conf)
+      case "file" => new FileSink(jobName, conf)
+      case "es" => new ESSink(jobName, conf)
+      case "s2graph" => new S2graphSink(jobName, conf)
+      case _ => throw new IllegalArgumentException(s"unsupported sink type : ${conf.`type`}")
+    }
+
+  }
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobLauncher.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobLauncher.scala
@@ -1,0 +1,69 @@
+package org.apache.s2graph.s2jobs
+
+import org.apache.spark.sql.SparkSession
+import play.api.libs.json.{JsValue, Json}
+
+import scala.io.Source
+
+case class JobOption(
+                      name:String = "S2BatchJob",
+                      confType:String = "db",
+                      jobId:Int = -1,
+                      confFile:String = ""
+                    )
+
+object JobLauncher extends Logger {
+
+  def parseArguments(args: Array[String]): JobOption = {
+    val parser = new scopt.OptionParser[JobOption]("run") {
+      opt[String]('n', "name").required().action((x, c) =>
+        c.copy(name = x)).text("job display name")
+
+      cmd("file").action((_, c) => c.copy(confType = "file"))
+        .text("get config from file")
+        .children(
+          opt[String]('f', "confFile").required().valueName("<file>").action((x, c) =>
+            c.copy(confFile = x)).text("configuration file")
+        )
+
+      cmd("db").action((_, c) => c.copy(confType = "db"))
+        .text("get config from db")
+        .children(
+          opt[String]('i', "jobId").required().valueName("<jobId>").action((x, c) =>
+            c.copy(jobId = x.toInt)).text("configuration file")
+        )
+    }
+
+    parser.parse(args, JobOption()) match {
+      case Some(o) => o
+      case None =>
+        parser.showUsage()
+        throw new IllegalArgumentException(s"failed to parse options... (${args.mkString(",")}")
+    }
+  }
+
+  def getConfig(options: JobOption):JsValue = options.confType match {
+    case "file" =>
+      Json.parse(Source.fromFile(options.confFile).mkString)
+    case "db" =>
+      throw new IllegalArgumentException(s"'db' option that read config file from database is not supported yet.. ")
+  }
+
+  def main(args: Array[String]): Unit = {
+
+    val options = parseArguments(args)
+    logger.info(s"Job Options : ${options}")
+
+    val jobDescription = JobDescription(getConfig(options))
+
+    val ss = SparkSession
+      .builder()
+      .appName(s"${jobDescription.name}")
+      .config("spark.driver.maxResultSize", "20g")
+      .enableHiveSupport()
+      .getOrCreate()
+
+    val job = new Job(ss, jobDescription)
+    job.run()
+  }
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Logger.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Logger.scala
@@ -1,0 +1,7 @@
+package org.apache.s2graph.s2jobs
+
+import org.apache.commons.logging.{Log, LogFactory}
+
+trait Logger {
+  @transient lazy val logger: Log = LogFactory.getLog(this.getClass)
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Schema.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/Schema.scala
@@ -1,0 +1,16 @@
+package org.apache.s2graph.s2jobs
+
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+
+object Schema {
+  val BulkLoadSchema = StructType(Seq(
+    StructField("timestamp", LongType, false),
+    StructField("operation", StringType, false),
+    StructField("elem", StringType, false),
+    StructField("from", StringType, false),
+    StructField("to", StringType, false),
+    StructField("label", StringType, false),
+    StructField("props", StringType, false),
+    StructField("direction", StringType, true)
+  ))
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Process.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Process.scala
@@ -1,0 +1,34 @@
+package org.apache.s2graph.s2jobs.task
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/**
+  * Process
+  * @param conf
+  */
+abstract class Process(override val conf:TaskConf) extends Task {
+  def execute(ss:SparkSession, inputMap:Map[String, DataFrame]):DataFrame
+}
+
+/**
+  * SqlProcess
+  * @param conf
+  */
+class SqlProcess(conf:TaskConf) extends Process(conf) {
+  override def mandatoryOptions: Set[String] = Set("sql")
+
+  override def execute(ss: SparkSession, inputMap: Map[String, DataFrame]): DataFrame = {
+    // create temp table
+    inputMap.foreach { case (name, df) =>
+      logger.debug(s"${LOG_PREFIX} create temp table : $name")
+      df.printSchema()
+      df.createOrReplaceTempView(name)
+    }
+
+    val sql = conf.options("sql")
+    logger.debug(s"${LOG_PREFIX} sql : $sql")
+
+    ss.sql(sql)
+  }
+}
+

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
@@ -163,3 +163,16 @@ class ESSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
   }
 }
 
+/**
+  * S2graphSink
+  * @param queryName
+  * @param conf
+  */
+class S2graphSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set()
+  override val FORMAT: String = "org.apache.s2graph.spark.sql.streaming.S2SinkProvider"
+
+  override protected def writeBatch(writer: DataFrameWriter[Row]): Unit =
+    throw new RuntimeException(s"unsupported source type for ${this.getClass.getSimpleName} : ${conf.name}")
+}
+

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
@@ -1,0 +1,165 @@
+package org.apache.s2graph.s2jobs.task
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.streaming.{DataStreamWriter, OutputMode, Trigger}
+import org.elasticsearch.spark.sql.EsSparkSQL
+
+/**
+  * Sink
+  * @param queryName
+  * @param conf
+  */
+abstract class Sink(queryName:String, override val conf:TaskConf) extends Task {
+  val DEFAULT_CHECKPOINT_LOCATION = s"/tmp/streamingjob/${queryName}"
+  val DEFAULT_TRIGGER_INTERVAL = "10 seconds"
+
+  val FORMAT:String
+
+  def preprocess(df:DataFrame):DataFrame = df
+
+  def write(inputDF: DataFrame):Unit = {
+    val df = repartition(preprocess(inputDF), inputDF.sparkSession.sparkContext.defaultParallelism)
+
+    if (inputDF.isStreaming) writeStream(df.writeStream)
+    else writeBatch(df.write)
+  }
+
+  protected def writeStream(writer: DataStreamWriter[Row]): Unit = {
+    val partitionsOpt = conf.options.get("partitions")
+    val mode = conf.options.getOrElse("mode", "append") match {
+      case "append" => OutputMode.Append()
+      case "update" => OutputMode.Update()
+      case "complete" => OutputMode.Complete()
+      case _ => logger.warn(s"${LOG_PREFIX} unsupported output mode. use default output mode 'append'")
+                OutputMode.Append()
+    }
+    val interval = conf.options.getOrElse("interval", DEFAULT_TRIGGER_INTERVAL)
+    val checkpointLocation = conf.options.getOrElse("checkpointLocation", DEFAULT_CHECKPOINT_LOCATION)
+
+    val cfg = conf.options ++ Map("checkpointLocation" -> checkpointLocation)
+
+    val partitionedWriter = if (partitionsOpt.isDefined) writer.partitionBy(partitionsOpt.get) else writer
+
+    val query = partitionedWriter
+      .queryName(queryName)
+      .format(FORMAT)
+      .options(cfg)
+      .trigger(Trigger.ProcessingTime(interval))
+      .outputMode(mode)
+      .start()
+
+    query.awaitTermination()
+  }
+
+  protected def writeBatch(writer: DataFrameWriter[Row]): Unit = {
+    val partitionsOpt = conf.options.get("partitions")
+    val mode = conf.options.getOrElse("mode", "overwrite") match {
+      case "overwrite" => SaveMode.Overwrite
+      case "append" => SaveMode.Append
+      case "errorIfExists" => SaveMode.ErrorIfExists
+      case "ignore" => SaveMode.Ignore
+      case _ => SaveMode.Overwrite
+    }
+
+    val partitionedWriter = if (partitionsOpt.isDefined) writer.partitionBy(partitionsOpt.get) else writer
+
+    writeBatchInner(partitionedWriter.format(FORMAT).mode(mode))
+  }
+
+  protected def writeBatchInner(writer: DataFrameWriter[Row]): Unit = {
+    val outputPath = conf.options("path")
+    writer.save(outputPath)
+  }
+
+  protected def repartition(df:DataFrame, defaultParallelism:Int) = {
+    conf.options.get("numPartitions").map(n => Integer.parseInt(n)) match {
+      case Some(numOfPartitions:Int) =>
+        if (numOfPartitions > defaultParallelism) df.repartition(numOfPartitions)
+        else df.coalesce(numOfPartitions)
+      case None => df
+    }
+  }
+}
+
+/**
+  * KafkaSink
+  * @param queryName
+  * @param conf
+  */
+class KafkaSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set("kafka.bootstrap.servers", "topic")
+  override val FORMAT: String = "kafka"
+
+  override def preprocess(df:DataFrame):DataFrame = {
+    import org.apache.spark.sql.functions._
+
+    logger.debug(s"${LOG_PREFIX} schema: ${df.schema}")
+
+    conf.options.getOrElse("format", "json") match {
+      case "tsv" =>
+        val delimiter = conf.options.getOrElse("delimiter", "\t")
+
+        val columns = df.columns
+        df.select(concat_ws(delimiter, columns.map(c => col(c)): _*).alias("value"))
+      case format:String =>
+        if (format != "json") logger.warn(s"${LOG_PREFIX} unsupported format '$format'. use default json format")
+        df.selectExpr("to_json(struct(*)) AS value")
+    }
+  }
+
+  override protected def writeBatch(writer: DataFrameWriter[Row]): Unit =
+    throw new RuntimeException(s"unsupported source type for ${this.getClass.getSimpleName} : ${conf.name}")
+}
+
+/**
+  * FileSink
+  * @param queryName
+  * @param conf
+  */
+class FileSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set("path", "format")
+  override val FORMAT: String = conf.options.getOrElse("format", "parquet")
+}
+
+/**
+  * HiveSink
+  * @param queryName
+  * @param conf
+  */
+class HiveSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set("database", "table")
+  override val FORMAT: String = "hive"
+
+  override protected def writeBatchInner(writer: DataFrameWriter[Row]): Unit = {
+    val database = conf.options("database")
+    val table = conf.options("table")
+
+    writer.insertInto(s"${database}.${table}")
+  }
+
+  override protected def writeStream(writer: DataStreamWriter[Row]): Unit =
+    throw new RuntimeException(s"unsupported source type for ${this.getClass.getSimpleName} : ${conf.name}")
+
+}
+
+/**
+  * ESSink
+  * @param queryName
+  * @param conf
+  */
+class ESSink(queryName:String, conf:TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set("es.nodes", "path", "es.port")
+  override val FORMAT: String = "es"
+
+  override def write(inputDF: DataFrame): Unit = {
+    val df = repartition(inputDF, inputDF.sparkSession.sparkContext.defaultParallelism)
+
+    if (inputDF.isStreaming) writeStream(df.writeStream)
+    else {
+
+      val resource = conf.options("path")
+      EsSparkSQL.saveToEs(df, resource, conf.options)
+    }
+  }
+}
+

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Source.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Source.scala
@@ -1,0 +1,85 @@
+package org.apache.s2graph.s2jobs.task
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+
+/**
+  * Source
+  *
+  * @param conf
+  */
+abstract class Source(override val conf:TaskConf) extends Task {
+  def toDF(ss:SparkSession):DataFrame
+}
+
+class KafkaSource(conf:TaskConf) extends Source(conf) {
+  val DEFAULT_FORMAT = "raw"
+  override def mandatoryOptions: Set[String] = Set("kafka.bootstrap.servers", "subscribe")
+
+  override def toDF(ss:SparkSession):DataFrame = {
+    logger.info(s"${LOG_PREFIX} options: ${conf.options}")
+
+    val format = conf.options.getOrElse("format", "raw")
+    val df = ss.readStream.format("kafka").options(conf.options).load()
+
+    format match {
+      case "raw" => df
+      case "json" => parseJsonSchema(ss, df)
+//      case "custom" => parseCustomSchema(df)
+      case _ =>
+        logger.warn(s"${LOG_PREFIX} unsupported format '$format'.. use default schema ")
+        df
+    }
+  }
+
+  def parseJsonSchema(ss:SparkSession, df:DataFrame):DataFrame = {
+    import org.apache.spark.sql.functions.from_json
+    import org.apache.spark.sql.types.DataType
+    import ss.implicits._
+
+    val schemaOpt = conf.options.get("schema")
+    schemaOpt match {
+      case Some(schemaAsJson:String) =>
+        val dataType:DataType = DataType.fromJson(schemaAsJson)
+        logger.debug(s"${LOG_PREFIX} schema : ${dataType.sql}")
+
+        df.selectExpr("CAST(value AS STRING)")
+          .select(from_json('value, dataType) as 'struct)
+          .select("struct.*")
+
+      case None =>
+        logger.warn(s"${LOG_PREFIX} json format does not have schema.. use default schema ")
+        df
+    }
+  }
+}
+
+class FileSource(conf:TaskConf) extends Source(conf) {
+  val DEFAULT_FORMAT = "parquet"
+  override def mandatoryOptions: Set[String] = Set("paths")
+
+  override def toDF(ss: SparkSession): DataFrame = {
+    import org.apache.s2graph.s2jobs.Schema._
+    val paths = conf.options("paths").split(",")
+    val format = conf.options.getOrElse("format", DEFAULT_FORMAT)
+
+    format match {
+      case "edgeLog" =>
+        ss.read.format("com.databricks.spark.csv").option("delimiter", "\t")
+          .schema(BulkLoadSchema).load(paths: _*)
+      case _ => ss.read.format(format).load(paths: _*)
+    }
+  }
+}
+
+class HiveSource(conf:TaskConf) extends Source(conf) {
+  override def mandatoryOptions: Set[String] = Set("database", "table")
+
+  override def toDF(ss: SparkSession): DataFrame = {
+    val database = conf.options("database")
+    val table = conf.options("table")
+
+    val sql = conf.options.getOrElse("sql", s"SELECT * FROM ${database}.${table}")
+    ss.sql(sql)
+  }
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Task.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Task.scala
@@ -1,0 +1,19 @@
+package org.apache.s2graph.s2jobs.task
+
+import org.apache.s2graph.s2jobs.Logger
+
+case class TaskConf(name:String, `type`:String, inputs:Seq[String] = Nil, options:Map[String, String] = Map.empty)
+
+trait Task extends Serializable with Logger {
+  val conf:TaskConf
+  val LOG_PREFIX = s"[${this.getClass.getSimpleName}]"
+
+  def mandatoryOptions:Set[String]
+  def isValidate:Boolean = mandatoryOptions.subsetOf(conf.options.keySet)
+
+  require(isValidate, s"""${LOG_PREFIX} not exists mandatory options '${mandatoryOptions.mkString(",")}'
+                          in task options (${conf.options.keySet.mkString(",")})
+                      """.stripMargin)
+
+  println(s"${LOG_PREFIX} init : $conf")
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/Logger.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/Logger.scala
@@ -1,0 +1,7 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import org.apache.commons.logging.{Log, LogFactory}
+
+trait Logger {
+  @transient lazy val logger: Log = LogFactory.getLog(this.getClass)
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2CommitProtocol.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2CommitProtocol.scala
@@ -1,0 +1,48 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import org.apache.spark.sql.execution.streaming.MetadataLog
+
+class S2CommitProtocol(@transient val commitLog: MetadataLog[Array[S2SinkStatus]])
+  extends Serializable with Logger {
+
+  def initJob(jobState: JobState): Unit = {
+    logger.debug(s"[InitJob] ${jobState}")
+  }
+
+  def commitJob(jobState: JobState, taskCommits: Seq[TaskCommit]): Unit = {
+    val commits = taskCommits.flatMap(_.statuses).toArray[S2SinkStatus]
+    if (commitLog.add(jobState.batchId, commits)) {
+      logger.debug(s"[Committed batch] ${jobState.batchId}  (${taskCommits})")
+    } else {
+      throw new IllegalStateException(s"Batch Id [${jobState.batchId}] is already committed")
+    }
+  }
+
+  def abortJob(jobState: JobState): Unit = {
+    logger.info(s"[AbortJob] ${jobState}")
+  }
+
+  @transient var executionStart: Long = _
+
+  def initTask(): Unit = {
+    executionStart = System.currentTimeMillis()
+  }
+
+  def commitTask(taskState: TaskState): TaskCommit = {
+    TaskCommit(Some(S2SinkStatus(taskState.taskId, executionStart, taskState.successCnt, taskState.failCnt, taskState.counter)))
+  }
+
+  def abortTask(taskState: TaskState): Unit = {
+    logger.info(s"[AbortTask] ${taskState}")
+    TaskCommit(None)
+  }
+}
+
+case class JobState(jobId: String, batchId: Long, dataCnt: Long = -1L)
+case class TaskState(
+                      taskId: Int,
+                      successCnt:Long = -1L,
+                      failCnt:Long = -1L,
+                      counter:Map[String, Int] = Map.empty
+                    )
+case class TaskCommit(statuses: Option[S2SinkStatus])

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkConfigs.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkConfigs.scala
@@ -1,0 +1,28 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+object S2SinkConfigs {
+  val DB_DEFAULT_URL = "db.default.url"
+  val HBASE_ZOOKEEPER_QUORUM = "hbase.zookeeper.quorum"
+
+
+  val DEFAULT_GROUPED_SIZE = "100"
+  val DEFAULT_WAIT_TIME_SECONDS = "5"
+
+  val S2_SINK_PREFIX = "s2.spark.sql.streaming.sink"
+  val S2_SINK_QUERY_NAME = s"$S2_SINK_PREFIX.queryname"
+  val S2_SINK_LOG_PATH = s"$S2_SINK_PREFIX.logpath"
+  val S2_SINK_CHECKPOINT_LOCATION = "checkpointlocation"
+  val S2_SINK_FILE_CLEANUP_DELAY = s"$S2_SINK_PREFIX.file.cleanup.delay"
+  val S2_SINK_DELETE_EXPIRED_LOG = s"$S2_SINK_PREFIX.delete.expired.log"
+  val S2_SINK_COMPACT_INTERVAL = s"$S2_SINK_PREFIX.compact.interval"
+  val S2_SINK_GROUPED_SIZE = s"$S2_SINK_PREFIX.grouped.size"
+  val S2_SINK_WAIT_TIME = s"$S2_SINK_PREFIX.wait.time"
+
+  def getConfigStringOpt(config:Config, path:String): Option[String] = Try(config.getString(path)).toOption
+
+  def getConfigString(config:Config, path:String, default:String): String = getConfigStringOpt(config, path).getOrElse(default)
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkContext.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkContext.scala
@@ -1,0 +1,25 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import com.typesafe.config.Config
+import org.apache.s2graph.core.S2Graph
+
+import scala.concurrent.ExecutionContext
+
+class S2SinkContext(config: Config)(implicit ec: ExecutionContext = ExecutionContext.Implicits.global){
+  println(s">>>> S2SinkContext Created...")
+  private lazy val s2Graph = new S2Graph(config)
+  def getGraph: S2Graph = {
+    s2Graph
+  }
+}
+
+object S2SinkContext {
+  private var s2SinkContext:S2SinkContext = null
+
+  def apply(config:Config):S2SinkContext = {
+    if (s2SinkContext == null) {
+      s2SinkContext = new S2SinkContext(config)
+    }
+    s2SinkContext
+  }
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkMetadataLog.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkMetadataLog.scala
@@ -1,0 +1,25 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import com.typesafe.config.Config
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.CompactibleFileStreamLog
+
+class S2SinkMetadataLog(sparkSession: SparkSession, config:Config, logPath:String)
+  extends CompactibleFileStreamLog[S2SinkStatus](S2SinkMetadataLog.VERSION, sparkSession, logPath) {
+  import S2SinkConfigs._
+
+  override protected def fileCleanupDelayMs: Long = getConfigStringOpt(config, S2_SINK_FILE_CLEANUP_DELAY)
+                                                      .getOrElse("60").toLong
+
+  override protected def isDeletingExpiredLog: Boolean = getConfigStringOpt(config, S2_SINK_DELETE_EXPIRED_LOG)
+                                                            .getOrElse("false").toBoolean
+
+  override protected def defaultCompactInterval: Int = getConfigStringOpt(config, S2_SINK_COMPACT_INTERVAL)
+                                                          .getOrElse("60").toInt
+
+  override def compactLogs(logs: Seq[S2SinkStatus]): Seq[S2SinkStatus] = logs
+}
+
+object S2SinkMetadataLog {
+  private val VERSION = 1
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkProvider.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkProvider.scala
@@ -1,0 +1,26 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
+import org.apache.spark.sql.streaming.OutputMode
+
+import scala.collection.JavaConversions._
+
+class S2SinkProvider extends StreamSinkProvider with DataSourceRegister with Logger {
+  override def createSink(
+                  sqlContext: SQLContext,
+                  parameters: Map[String, String],
+                  partitionColumns: Seq[String],
+                  outputMode: OutputMode): Sink = {
+
+    logger.info(s"S2SinkProvider options : ${parameters}")
+    val jobConf:Config = ConfigFactory.parseMap(parameters).withFallback(ConfigFactory.load())
+    logger.info(s"S2SinkProvider Configuration : ${jobConf.root().render(ConfigRenderOptions.concise())}")
+
+    new S2SparkSqlStreamingSink(sqlContext.sparkSession, jobConf)
+  }
+
+  override def shortName(): String = "s2graph"
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkStatus.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SinkStatus.scala
@@ -1,0 +1,9 @@
+package org.apache.s2graph.spark.sql.streaming
+
+case class S2SinkStatus(
+                         taskId: Int,
+                         execTimeMillis: Long,
+                         successCnt:Long,
+                         failCnt:Long,
+                         counter:Map[String, Int]
+                       )

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SparkSqlStreamingSink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SparkSqlStreamingSink.scala
@@ -1,0 +1,71 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import java.util.UUID
+
+import com.typesafe.config.{Config, ConfigRenderOptions}
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.streaming.{MetadataLog, Sink}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+class S2SparkSqlStreamingSink(
+                               sparkSession: SparkSession,
+                               config:Config
+                             ) extends Sink with Logger {
+  import S2SinkConfigs._
+
+  private val APP_NAME = "s2graph"
+
+  private val writeLog: MetadataLog[Array[S2SinkStatus]] = {
+    val logPath = getCommitLogPath(config)
+    logger.info(s"MetaDataLogPath: $logPath")
+
+    new S2SinkMetadataLog(sparkSession, config, logPath)
+  }
+
+  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+    val dataCnt = data.count()
+    logger.debug(s"addBatch : $batchId, getLatest : ${writeLog.getLatest()}, data cnt : ${dataCnt}")
+
+    if (batchId <= writeLog.getLatest().map(_._1).getOrElse(-1L)) {
+      logger.info(s"Skipping already committed batch [$batchId]")
+    } else {
+      val queryName = getConfigStringOpt(config, "queryname").getOrElse(UUID.randomUUID().toString)
+      val commitProtocol = new S2CommitProtocol(writeLog)
+      val jobState = JobState(queryName, batchId, dataCnt)
+      val serializedConfig = config.root().render(ConfigRenderOptions.concise())
+      val queryExecution = data.queryExecution
+      val schema = data.schema
+
+      SQLExecution.withNewExecutionId(sparkSession, queryExecution) {
+        try {
+          val taskCommits = sparkSession.sparkContext.runJob(queryExecution.toRdd,
+            (taskContext: TaskContext, iter: Iterator[InternalRow]) => {
+              new S2StreamQueryWriter(serializedConfig, schema, commitProtocol).run(taskContext, iter)
+            }
+          )
+          commitProtocol.commitJob(jobState, taskCommits)
+        } catch {
+          case t: Throwable =>
+            commitProtocol.abortJob(jobState)
+            throw t;
+        }
+
+      }
+    }
+  }
+
+  private def getCommitLogPath(config:Config): String = {
+    val logPathOpt = getConfigStringOpt(config, S2_SINK_LOG_PATH)
+    val userCheckpointLocationOpt = getConfigStringOpt(config, S2_SINK_CHECKPOINT_LOCATION)
+
+    (logPathOpt, userCheckpointLocationOpt) match {
+      case (Some(logPath), _) => logPath
+      case (None, Some(userCheckpoint)) => s"$userCheckpoint/sinks/$APP_NAME"
+      case _ => throw new IllegalArgumentException(s"failed to get commit log path")
+    }
+  }
+
+  override def toString(): String = "S2GraphSink"
+}

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SparkSqlStreamingSink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2SparkSqlStreamingSink.scala
@@ -25,15 +25,14 @@ class S2SparkSqlStreamingSink(
   }
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
-    val dataCnt = data.count()
-    logger.debug(s"addBatch : $batchId, getLatest : ${writeLog.getLatest()}, data cnt : ${dataCnt}")
+    logger.debug(s"addBatch : $batchId, getLatest : ${writeLog.getLatest()}")
 
     if (batchId <= writeLog.getLatest().map(_._1).getOrElse(-1L)) {
       logger.info(s"Skipping already committed batch [$batchId]")
     } else {
       val queryName = getConfigStringOpt(config, "queryname").getOrElse(UUID.randomUUID().toString)
       val commitProtocol = new S2CommitProtocol(writeLog)
-      val jobState = JobState(queryName, batchId, dataCnt)
+      val jobState = JobState(queryName, batchId)
       val serializedConfig = config.root().render(ConfigRenderOptions.concise())
       val queryExecution = data.queryExecution
       val schema = data.schema

--- a/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2StreamQueryWriter.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/spark/sql/streaming/S2StreamQueryWriter.scala
@@ -1,0 +1,114 @@
+package org.apache.s2graph.spark.sql.streaming
+
+import com.typesafe.config.ConfigFactory
+import org.apache.s2graph.core.{GraphElement, JSONParser}
+import org.apache.s2graph.spark.sql.streaming.S2SinkConfigs._
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.types.StructType
+import play.api.libs.json.{JsObject, Json}
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+private [sql] class S2StreamQueryWriter(
+                                         serializedConf:String,
+                                         schema: StructType ,
+                                         commitProtocol: S2CommitProtocol
+                                       ) extends Serializable with Logger {
+  private val config = ConfigFactory.parseString(serializedConf)
+  private val s2SinkContext = S2SinkContext(config)
+  private val encoder: ExpressionEncoder[Row] = RowEncoder(schema).resolveAndBind()
+  private val RESERVED_COLUMN = Set("timestamp", "from", "to", "label", "operation", "elem", "direction")
+
+
+  def run(taskContext: TaskContext, iters: Iterator[InternalRow]): TaskCommit = {
+    val taskId = s"stage-${taskContext.stageId()}, partition-${taskContext.partitionId()}, attempt-${taskContext.taskAttemptId()}"
+    val partitionId= taskContext.partitionId()
+
+    val s2Graph = s2SinkContext.getGraph
+    val groupedSize = getConfigString(config, S2_SINK_GROUPED_SIZE, DEFAULT_GROUPED_SIZE).toInt
+    val waitTime = getConfigString(config, S2_SINK_WAIT_TIME, DEFAULT_WAIT_TIME_SECONDS).toInt
+
+    commitProtocol.initTask()
+    try {
+      var list = new ListBuffer[(String, Int)]()
+      val rst = iters.flatMap(rowToEdge).grouped(groupedSize).flatMap{ elements =>
+        logger.debug(s"[$taskId][elements] ${elements.size} (${elements.map(e => e.toLogString).mkString(",\n")})")
+        elements.groupBy(_.serviceName).foreach{ case (service, elems) =>
+          list += ((service, elems.size))
+        }
+
+        val mutateF = s2Graph.mutateElements(elements, true)
+        Await.result(mutateF, Duration(waitTime, "seconds"))
+      }
+
+      val (success, fail) = rst.toSeq.partition(r => r.isSuccess)
+      val counter = list.groupBy(_._1).map{ case (service, t) =>
+        val sum = t.toList.map(_._2).sum
+        (service, sum)
+      }
+      logger.info(s"[$taskId] success : ${success.size}, fail : ${fail.size} ($counter)")
+
+
+      commitProtocol.commitTask(TaskState(partitionId, success.size, fail.size, counter))
+
+    } catch {
+      case t: Throwable =>
+        commitProtocol.abortTask(TaskState(partitionId))
+        throw t
+    }
+  }
+
+  private def rowToEdge(internalRow:InternalRow): Option[GraphElement] = {
+    val s2Graph = s2SinkContext.getGraph
+    val row = encoder.fromRow(internalRow)
+
+    val timestamp = row.getAs[Long]("timestamp")
+    val operation = Try(row.getAs[String]("operation")).getOrElse("insert")
+    val elem = Try(row.getAs[String]("elem")).getOrElse("e")
+
+    val props: Map[String, Any] = Option(row.getAs[String]("props")) match {
+      case Some(propsStr:String) =>
+        JSONParser.fromJsonToProperties(Json.parse(propsStr).as[JsObject])
+      case None =>
+        schema.fieldNames.flatMap { field =>
+          if (!RESERVED_COLUMN.contains(field)) {
+            Seq(
+              field -> getRowValAny(row, field)
+            )
+          } else Nil
+        }.toMap
+    }
+
+    elem match {
+      case "e" | "edge" =>
+        val from = getRowValAny(row, "from")
+        val to = getRowValAny(row, "to")
+        val label = row.getAs[String]("label")
+        val direction = Try(row.getAs[String]("direction")).getOrElse("out")
+        Some(
+          s2Graph.elementBuilder.toEdge(from, to, label, direction, props, timestamp, operation)
+        )
+      case "v" | "vertex" =>
+        val id = getRowValAny(row, "id")
+        val serviceName = row.getAs[String]("service")
+        val columnName = row.getAs[String]("column")
+        Some(
+          s2Graph.elementBuilder.toVertex(serviceName, columnName, id, props, timestamp, operation)
+        )
+      case _ =>
+        logger.warn(s"'$elem' is not GraphElement. skipped!! (${row.toString()})")
+        None
+    }
+  }
+
+  private def getRowValAny(row:Row, fieldName:String):Any = {
+    val idx = row.fieldIndex(fieldName)
+    row.get(idx)
+  }
+}

--- a/s2jobs/src/test/scala/org/apache/s2graph/s2jobs/task/ProcessTest.scala
+++ b/s2jobs/src/test/scala/org/apache/s2graph/s2jobs/task/ProcessTest.scala
@@ -1,0 +1,29 @@
+package org.apache.s2graph.s2jobs.task
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.FunSuite
+
+class ProcessTest extends FunSuite with DataFrameSuiteBase {
+
+  test("SqlProcess execute sql") {
+    import spark.implicits._
+
+    val inputDF = Seq(
+      ("a", "b", "friend"),
+      ("a", "c", "friend"),
+      ("a", "d", "friend")
+    ).toDF("from", "to", "label")
+
+    val inputMap = Map("input" -> inputDF)
+    val sql = "SELECT * FROM input WHERE to = 'b'"
+    val conf = TaskConf("test", "sql", Seq("input"), Map("sql" -> sql))
+
+    val process = new SqlProcess(conf)
+
+    val rstDF = process.execute(spark, inputMap)
+    val tos = rstDF.collect().map{ row => row.getAs[String]("to")}
+
+    assert(tos.size == 1)
+    assert(tos.head == "b")
+  }
+}


### PR DESCRIPTION


I added a simple job launcher using spark structured streaming, which consists of three parts: source, process, and sink.

The source and sink can use the built-in types supported by structured streaming and can be added using the type provided by the 3rd party or by directly implementing.

For data processing, provide SQLProcess using SparkSql and udf, and can implement custom class if necessary.
 
 
## Current Supported Task
### Source
* kakfa : built-in
* file : built-in
* hive : built-in

### Process
* sql : process spark sql
* custom : implement if necessary

### Sink
* kafka : built-in
* file : built-in
* es : elasticsearch-spark
* s2graph : added
  
  * Use the mutateElement function of the S2graph object.
  * S2graph related setting is required.
  * put the config file in the classpath or specify it in the job description options.
  ```
  ex)
      "type": "s2graph",
      "options": {
        "hbase.zookeeper.quorum": "",
        "db.default.driver": "",
        "db.default.url": ""
      }
  ```



## Job Description

Tasks and workflow can be described in job description.
And dependencies between tasks are defined by the name of the task specified in the inputs field

I referenced the [airstream of Airbnb](https://www.slideshare.net/databricks/building-data-product-based-on-apache-spark-at-airbnb-with-jingwei-lu-and-liyin-tang) for the specification of the job description.

### Json Spec
```
{
    "name": "JOB_NAME",
    "source": [
        {
            "name": "TASK_NAME",
            "inputs": [],
            "type": "SOURCE_TYPE",
            "options": {
                "KEY" : "VALUE"
            }
        }
    ],
    "process": [
        {
            "name": "TASK_NAME",
            "inputs": ["INPUT_TASK_NAME"],
            "type": "PROCESS_TYPE",
            "options": {
                "KEY" : "VALUE"
            }
        }
    ],
    "sink": [
        {
            "name": "TASK_NAME",
            "inputs": ["INPUT_TASK_NAME"],
            "type": "SINK_TYPE",
            "options": {
                "KEY" : "VALUE"
            }
        }
    ]
}
```

## Data Schema for Kafka 
When using Kafka as data source consumer needs to parse it and later on interpret it, because of Kafka has no schema.

When reading data from Kafka with structure streaming, the Dataframe has the following schema.
```
Column    Type
key        binary
value    binary
topic    string
partition    int
offset    long
timestamp    long
timestampType    int
```

In the case of JSON format, data schema can be supported in config.
You can create a schema by giving a string representing the struct type as JSON as shown below.
```
{
  "type": "struct",
  "fields": [
    {
      "name": "timestamp",
      "type": "long",
      "nullable": false,
      "metadata": {}
    },
    {
      "name": "operation",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "elem",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "from",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "to",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "label",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "service",
      "type": "string",
      "nullable": true,
      "metadata": {}
    },
    {
      "name": "props",
      "type": "string",
      "nullable": true,
      "metadata": {}
    }
  ]
}
```


## Sample job
### wallog trasnform (kafka to kafka)
```
{
    "name": "kafkaJob",
    "source": [
        {
            "name": "wal",
            "inputs": [],
            "type": "kafka",
            "options": {
                "kafka.bootstrap.servers" : "localhost:9092",
                "subscribe": "s2graphInJson",
                "maxOffsetsPerTrigger": "10000",
                "format": "json",
                "schema": "{\"type\":\"struct\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"nullable\":false,\"metadata\":{}},{\"name\":\"operation\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"elem\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"from\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"to\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"label\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"service\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"props\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}"
            }
        }
    ],
    "process": [
        {
            "name": "transform",
            "inputs": ["wal"],
            "type": "sql",
            "options": {
                "sql": "SELECT timestamp, `from` as userId, to as itemId, label as action FROM wal WHERE label = 'user_action'"
            }
        }
    ],
    "sink": [
        {
            "name": "kafka_sink",
            "inputs": ["transform"],
            "type": "kafka",
            "options": {
                "kafka.bootstrap.servers" : "localhost:9092",
                "topic": "s2graphTransform",
                "format": "json"
            }
        }
    ]
}
```

### wallog transform (hdfs to hdfs)

```
{
    "name": "hdfsJob",
    "source": [
        {
            "name": "wal",
            "inputs": [],
            "type": "file",
            "options": {
                "paths": "/wal",
                "format": "parquet"
            }
        }
    ],
    "process": [
        {
            "name": "transform",
            "inputs": ["wal"],
            "type": "sql",
            "options": {
                "sql": "SELECT timestamp, `from` as userId, to as itemId, label as action FROM wal WHERE label = 'user_action'"
            }
        }
    ],
    "sink": [
        {
            "name": "hdfs_sink",
            "inputs": ["transform"],
            "type": "file",
            "options": {
                "path": "/wal_transform",
                "format": "json"
            }
        }
    ]
}
```

### Launch Job

When submitting spark job with assembly jar, use these parameters with the job description file path.
(currently only support file type)

```
// main class : org.apache.s2graph.s2jobs.JobLauncher
Usage: run [file|db] [options]
  -n, --name <value>      job display name
Command: file [options]
get config from file
  -f, --confFile <file>   configuration file
Command: db [options]
get config from db
  -i, --jobId <jobId>     configuration file
  ```
