### PR TITLE
[S2GRAPH-191] Providing request / response logging to GraphQL server and removing println

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -48,7 +48,8 @@ object Common {
     ExclusionRule("org.slf4j", "jcl-over-slf4j"),
     ExclusionRule("org.slf4j", "log4j-over-slf4j"),
     ExclusionRule("org.slf4j", "slf4j-log4j12"),
-    ExclusionRule("org.slf4j", "jul-to-slf4j")
+    ExclusionRule("org.slf4j", "jul-to-slf4j"),
+    ExclusionRule("org.apache.logging.log4j", "log4j-slf4j-impl")
   )
 
   implicit class LoggingExcluder(moduleId: ModuleID) {

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/HttpServer.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/HttpServer.scala
@@ -25,38 +25,38 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.ActorMaterializer
+import org.slf4j.LoggerFactory
 
-import scala.Console._
 import scala.concurrent.Await
 import scala.language.postfixOps
 
 object Server extends App {
+  val logger = LoggerFactory.getLogger(this.getClass)
 
-  implicit val actorSystem = ActorSystem("s2graphql-server")
+  implicit val system = ActorSystem("s2graphql-server")
   implicit val materializer = ActorMaterializer()
 
-  import actorSystem.dispatcher
+  import system.dispatcher
 
   import scala.concurrent.duration._
 
-  println("Starting GRAPHQL server...")
-
-  val route: Route =
-    (post & path("graphql")) {
-      entity(as[spray.json.JsValue])(GraphQLServer.endpoint)
-    } ~ {
-      getFromResource("assets/graphiql.html")
-    }
+  val route: Route = (post & path("graphql")) {
+    entity(as[spray.json.JsValue])(GraphQLServer.endpoint)
+  } ~ {
+    getFromResource("assets/graphiql.html")
+  }
 
   val port = sys.props.get("http.port").fold(8000)(_.toInt)
+
+  logger.info(s"Starting GraphQL server... ${port}")
   Http().bindAndHandle(route, "0.0.0.0", port)
 
-
   def shutdown(): Unit = {
-    println("Terminating...")
-    actorSystem.terminate()
-    Await.result(actorSystem.whenTerminated, 10 seconds)
+    logger.info("Terminating...")
 
-    println("Terminated.")
+    system.terminate()
+    Await.result(system.whenTerminated, 30 seconds)
+
+    logger.info("Terminated.")
   }
 }


### PR DESCRIPTION
1. I removed the dependency by adding `ExclusionRule (" org.apache.logging.log4j "," log4j-slf4j-impl ")` to `Common.scala` to fix` multiple_binding` error.

```bash
s2graphql[ERROR] SLF4J: Class path contains multiple SLF4J bindings.
s2graphql[ERROR] SLF4J: Found binding in [jar:file:/Users/daewon/.ivy2/cache/org.apache.logging.log4j/log4j-slf4j-impl/jars/log4j-slf4j-impl-2.9.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
s2graphql[ERROR] SLF4J: Found binding in [jar:file:/Users/daewon/.ivy2/cache/org.slf4j/slf4j-log4j12/jars/slf4j-log4j12-1.7.21.jar!/org/slf4j/impl/StaticLoggerBinder.class]
s2graphql[ERROR] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
s2graphql[ERROR] SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
s2graphql[ERROR] ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console. Set system property 'log4j2.debug' to show Log4j2 internal initialization logging.
```

2. Added logging for error messages.
From now on, if an error occurs as below, you can see that the same message is also recorded in the server log.
```bash
8095 [pool-7-thread-2] WARN  org.apache.s2graph.graphql.repository.GraphRepository  - createService Failed:
java.lang.RuntimeException: Service (daewon) already exists
        at org.apache.s2graph.graphql.repository.GraphRepository.createService(GraphRepository.scala:110)
        at org.apache.s2graph.graphql.types.S2ManagementType$$anonfun$10.apply(S2ManagementType.scala:308)
        at org.apache.s2graph.graphql.types.S2ManagementType$$anonfun$10.apply(S2ManagementType.scala:308)
        at sangria.execution.Resolver.resolveField(Resolver.scala:1024)
        at sangria.execution.Resolver$$anonfun$collectActionsPar$1.apply(Resolver.scala:445)
        at sangria.execution.Resolver$$anonfun$collectActionsPar$1.apply(Resolver.scala:439)
        at scala.collection.TraversableOnce$$anonfun$foldLeft$1.apply(TraversableOnce.scala:155)
 
```
![2018-03-29 4 33 28](https://user-images.githubusercontent.com/1182522/38076135-af29f05e-336f-11e8-9f33-e113d43a90a3.png)
