### PR TITLE
[S2GRAPH-192] could not find service column when creating the label 

### DIFF
--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2ManagementType.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2ManagementType.scala
@@ -77,7 +77,7 @@ class S2ManagementType(repo: GraphRepository) {
 
   lazy val serviceColumnOnServiceWithPropInputObjectFields = repo.allServices.map { service =>
     InputField(service.serviceName, OptionInputType(InputObjectType(
-      s"Input_Column_Props",
+      s"Input_${service.serviceName}_ServiceColumn_Props",
       description = "desc here",
       fields = List(
         InputField("columnName", makeServiceColumnEnumTypeOnService(service)),
@@ -88,7 +88,7 @@ class S2ManagementType(repo: GraphRepository) {
 
   lazy val serviceColumnOnServiceInputObjectFields = repo.allServices.map { service =>
     InputField(service.serviceName, OptionInputType(InputObjectType(
-      s"Input_Column",
+      s"Input_${service.serviceName}_ServiceColumn",
       description = "desc here",
       fields = List(
         InputField("columnName", makeServiceColumnEnumTypeOnService(service))

--- a/s2graphql/src/test/scala/org/apache/s2graph/graphql/SchemaTest.scala
+++ b/s2graphql/src/test/scala/org/apache/s2graph/graphql/SchemaTest.scala
@@ -19,9 +19,9 @@
 
 package org.apache.s2graph.graphql
 
-import com.typesafe.config.{ConfigFactory}
-import org.apache.s2graph.core.utils.logger
+import com.typesafe.config.ConfigFactory
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -29,11 +29,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import sangria.execution.Executor
 import sangria.parser.QueryParser
 
-
 import scala.util._
 
 class SchemaTest extends FunSuite with Matchers with BeforeAndAfterAll {
   var testGraph: TestGraph = _
+  val logger = LoggerFactory.getLogger(this.getClass)
 
   override def beforeAll = {
     val config = ConfigFactory.load()
@@ -64,10 +64,15 @@ class SchemaTest extends FunSuite with Matchers with BeforeAndAfterAll {
       Map("data" ->
         Map("__schema" ->
           Map("types" -> Vector(
+
+            // static s2graph constant types
             Map("name" -> "Enum_CompressionAlgorithm"),
             Map("name" -> "Enum_Consistency"),
             Map("name" -> "Enum_DataType"),
             Map("name" -> "Enum_Direction"),
+            Map("name" -> "Enum_Service"),
+            Map("name" -> "Enum_Label"),
+            Map("name" -> "Enum_kakao_ServiceColumn"),
 
             Map("name" -> "MutateLabel"),
             Map("name" -> "MutateGraphElement"),
@@ -77,8 +82,6 @@ class SchemaTest extends FunSuite with Matchers with BeforeAndAfterAll {
             Map("name" -> "Input_Service"),
             Map("name" -> "Input_Index"),
             Map("name" -> "Input_Prop"),
-            Map("name" -> "Input_Column"),
-            Map("name" -> "Input_Column_Props"),
 
             Map("name" -> "ColumnMeta"),
             Map("name" -> "LabelMeta"),
@@ -91,15 +94,16 @@ class SchemaTest extends FunSuite with Matchers with BeforeAndAfterAll {
 
             Map("name" -> "Input_Service_ServiceColumn"),
             Map("name" -> "Input_Service_ServiceColumn_Props"),
+
+            // dynamic created types
             Map("name" -> "Input_label_friends_param"),
             Map("name" -> "Input_vertex_kakao_param"),
 
+            Map("name" -> "Input_kakao_ServiceColumn_Props"),
+            Map("name" -> "Input_kakao_ServiceColumn"),
+
             Map("name" -> "Input_kakao_user"),
             Map("name" -> "Input_kakao_user_vertex_mutate"),
-
-            Map("name" -> "Enum_Service"),
-            Map("name" -> "Enum_Label"),
-            Map("name" -> "Enum_kakao_ServiceColumn"),
 
             Map("name" -> "Service_kakao"),
 


### PR DESCRIPTION
There was a bug in naming collision when 'sourceService' and 'targetService' types of 'Argument' used in 'CreateLabel' type were created.

In GraphQL rules, 'ObjectType' has to have unique name inside schema, but when service is more than 2, it has not got name for each service.