### PR TITLE
[S2Graph-200]  add extra jar in classpath dynamically when launching docker image

### DIFF
--- a/dev_support/README.md
+++ b/dev_support/README.md
@@ -22,8 +22,25 @@
 # Run S2Graph using Docker
 
 1. Build a docker image of the s2graph in the project's root directory
-	- `sbt "project s2rest_play" 'set version := "latest"' docker:publishLocal`
+	- you can build images for each type of API Server
+	    ```
+	    // s2graphql
+	    sbt "project s2graphql" 'set version := "latest"' docker
+	    
+	    // s2rest_play
+	    sbt "project s2rest_play" 'set version := "latest"' docker
+	    
+	    // s2rest_netty
+	    sbt "project s2rest_netty" 'set version := "latest"' docker
+	    ```
+	    
 	- find local image is created correctly by using `docker images`
+	
+	- (optional) If you need to add extra jars in classpath, use environment variable 'EXTRA_JARS'
+	    ```
+        docker run --name s2graph -v /LocalJarsDir:/extraJars -e EXTRA_JARS=/extraJars -dit s2graph/s2graphql:latest ...
+        ```
+	
 2. Run MySQL and HBase container first.
 	- change directory to dev-support. `cd dev_support`
 	- `docker-compose build` 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -35,5 +35,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+
 resolvers += Resolver.typesafeRepo("releases")
 

--- a/s2rest_netty/build.sbt
+++ b/s2rest_netty/build.sbt
@@ -20,8 +20,6 @@ import Common._
 
 name := "s2rest_netty"
 
-enablePlugins(JavaAppPackaging)
-
 libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "12.0.1" force(), // use this old version of guava to avoid incompatibility
   "io.netty" % "netty-all" % "4.0.33.Final"

--- a/s2rest_play/build.sbt
+++ b/s2rest_play/build.sbt
@@ -29,5 +29,3 @@ libraryDependencies ++= Seq(ws, filters, specs2 % Test).map(_.excludeLogging()) 
 )
 
 routesGenerator := StaticRoutesGenerator
-
-enablePlugins(JavaServerAppPackaging)


### PR DESCRIPTION
Currently, we support to build docker image through docker plugin of sbt-native-packager.
When packaging with the native-packager, the generated executable scripts add only the jars in the lib directory to the classpath.


```
//  default application structure
bin/
  <app_name>       <- BASH script
  <app_name>.bat   <- cmd.exe script
lib/
   <Your project and dependent jar files here.>
```

I added some command to copy extra jar on the classpath, in the executable scripts

When launching docker image, if we need to add extra jars in classpath, we could use environment variable 'EXTRA_JARS'
ex) 
```
docker run --name s2graph -v /LocalJarsDir:/extraJars -e EXTRA_JARS=/extraJars -dit s2graph/s2graphql:latest ...
```





Additionally, I used the [sbt-docker plugin](https://github.com/marcuslonnberg/sbt-docker).
We can use these commands below:
```
sbt docker
sbt dockerPush
sbt dockerBuildAndPush
```