### PR TITLE
[S2GRAPH-204] Avoid N + 1 queries in GraphQL

### DIFF
--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
@@ -27,12 +27,45 @@ import org.apache.s2graph.core.storage.MutateResponse
 import org.apache.s2graph.core.types._
 import org.apache.s2graph.graphql.types.S2Type._
 import org.slf4j.{Logger, LoggerFactory}
+import sangria.execution.deferred._
 import sangria.schema._
 
 import scala.concurrent._
 import scala.util.{Failure, Success, Try}
 
 object GraphRepository {
+
+  implicit val vertexHasId = new HasId[S2VertexLike, S2VertexLike] {
+    override def id(value: S2VertexLike): S2VertexLike = value
+  }
+
+  implicit val edgeHasId = new HasId[(S2VertexLike, QueryParam, Seq[S2EdgeLike]), DeferFetchEdges] {
+    override def id(value: (S2VertexLike, QueryParam, Seq[S2EdgeLike])): DeferFetchEdges =
+      DeferFetchEdges(value._1, value._2)
+  }
+
+  val vertexFetcher = Fetcher((ctx: GraphRepository, ids: Seq[S2VertexLike]) => {
+    ctx.getVertices(ids)
+  })
+
+  val edgeFetcher = Fetcher((ctx: GraphRepository, ids: Seq[DeferFetchEdges]) => {
+    implicit val ec = ctx.ec
+
+    val edgesByParam = ids.groupBy(_.qp).map { case (qp, deLs) =>
+      val vertices = deLs.map(de => de.v)
+
+      ctx.getEdges(vertices, qp).map(qp -> _)
+    }
+
+    val f: Future[Iterable[(QueryParam, Seq[S2EdgeLike])]] = Future.sequence(edgesByParam)
+    val grouped = f.map { tpLs =>
+      tpLs.toSeq.flatMap { case (qp, edges) =>
+        edges.groupBy(_.srcForVertex).map { case (v, edges) => (v, qp, edges) }
+      }
+    }
+
+    grouped
+  })
 
   def withLogTryResponse[A](opName: String, tryObj: Try[A])(implicit logger: Logger): Try[A] = {
     tryObj match {
@@ -42,6 +75,9 @@ object GraphRepository {
 
     tryObj
   }
+
+  case class DeferFetchEdges(v: S2VertexLike, qp: QueryParam)
+
 }
 
 class GraphRepository(val graph: S2GraphLike) {
@@ -87,6 +123,13 @@ class GraphRepository(val graph: S2GraphLike) {
 
   def getVertices(vertex: Seq[S2VertexLike]): Future[Seq[S2VertexLike]] = {
     graph.getVertices(vertex)
+  }
+
+  def getEdges(vertices: Seq[S2VertexLike], queryParam: QueryParam): Future[Seq[S2EdgeLike]] = {
+    val step = Step(Seq(queryParam))
+    val q = Query(vertices, steps = Vector(step))
+
+    graph.getEdges(q).map(_.edgeWithScores.map(_.edge))
   }
 
   def getEdges(vertex: S2VertexLike, queryParam: QueryParam): Future[Seq[S2EdgeLike]] = {
@@ -232,13 +275,9 @@ class GraphRepository(val graph: S2GraphLike) {
     withLogTryResponse("deleteLabel", deleteLabelTry)
   }
 
-  def allServices(): List[Service] = Service.findAll()
+  def services(): List[Service] = Service.findAll()
 
-  def allServiceColumns(): List[ServiceColumn] = ServiceColumn.findAll()
+  def serviceColumns(): List[ServiceColumn] = ServiceColumn.findAll()
 
-  def findServiceByName(name: String): Option[Service] = Service.findByName(name)
-
-  def allLabels() = Label.findAll()
-
-  def findLabelByName(name: String): Option[Label] = Label.findByName(name)
+  def labels() = Label.findAll()
 }

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/ManagementType.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/ManagementType.scala
@@ -67,7 +67,7 @@ class ManagementType(repo: GraphRepository) {
   import org.apache.s2graph.graphql.bind.Unmarshaller._
   import org.apache.s2graph.graphql.types.StaticTypes._
 
-  lazy val serviceColumnOnServiceWithPropInputObjectFields = repo.allServices.map { service =>
+  lazy val serviceColumnOnServiceWithPropInputObjectFields = repo.services().map { service =>
     InputField(service.serviceName, OptionInputType(InputObjectType(
       s"Input_${service.serviceName}_ServiceColumn_Props",
       description = "desc here",
@@ -78,7 +78,7 @@ class ManagementType(repo: GraphRepository) {
     )))
   }
 
-  lazy val serviceColumnOnServiceInputObjectFields = repo.allServices.map { service =>
+  lazy val serviceColumnOnServiceInputObjectFields = repo.services().map { service =>
     InputField(service.serviceName, OptionInputType(InputObjectType(
       s"Input_${service.serviceName}_ServiceColumn",
       description = "desc here",
@@ -99,7 +99,7 @@ class ManagementType(repo: GraphRepository) {
     )
   }
 
-  lazy val labelPropsInputFields = repo.allLabels().map { label =>
+  lazy val labelPropsInputFields = repo.labels().map { label =>
     InputField(label.label, OptionInputType(InputObjectType(
       s"Input_${label.label}_props",
       description = "desc here",
@@ -135,7 +135,7 @@ class ManagementType(repo: GraphRepository) {
     s"Enum_Service",
     description = Option("desc here"),
     values =
-      dummyEnum +: repo.allServices.map { service =>
+      dummyEnum +: repo.services().map { service =>
         EnumValue(service.serviceName, value = service.serviceName)
       }
   )
@@ -144,7 +144,7 @@ class ManagementType(repo: GraphRepository) {
     s"Enum_ServiceColumn",
     description = Option("desc here"),
     values =
-      dummyEnum +: repo.allServiceColumns.map { serviceColumn =>
+      dummyEnum +: repo.serviceColumns().map { serviceColumn =>
         EnumValue(serviceColumn.columnName, value = serviceColumn.columnName)
       }
   )
@@ -153,7 +153,7 @@ class ManagementType(repo: GraphRepository) {
     s"Enum_Label",
     description = Option("desc here"),
     values =
-      dummyEnum +: repo.allLabels().map { label =>
+      dummyEnum +: repo.labels().map { label =>
         EnumValue(label.label, value = label.label)
       }
   )
@@ -183,8 +183,8 @@ class ManagementType(repo: GraphRepository) {
     arguments = List(LabelNameArg),
     resolve = { c =>
       c.argOpt[String]("name") match {
-        case Some(name) => c.ctx.allLabels().filter(_.label == name)
-        case None => c.ctx.allLabels()
+        case Some(name) => c.ctx.labels().filter(_.label == name)
+        case None => c.ctx.labels()
       }
     }
   )
@@ -222,8 +222,8 @@ class ManagementType(repo: GraphRepository) {
     arguments = List(ServiceNameArg),
     resolve = { c =>
       c.argOpt[String]("name") match {
-        case Some(name) => c.ctx.allServices.filter(_.serviceName == name)
-        case None => c.ctx.allServices
+        case Some(name) => c.ctx.services().filter(_.serviceName == name)
+        case None => c.ctx.services()
       }
     }
   )


### PR DESCRIPTION
I removed the part where 'N + 1' queries occur in queries that fetch Vertices and Edges using 'DeferredResolver' provided by sangria framework.

http://sangria-graphql.org/learn/#deferred-value-resolution

