### PR TITLE
[S2GRAPH-207] Provides a way to query data with the value of the Vertex property in a GraphQL query.

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -33,7 +33,8 @@ import org.apache.s2graph.core.storage.rocks.RocksStorage
 import org.apache.s2graph.core.storage.{MutateResponse, Storage}
 import org.apache.s2graph.core.types._
 import org.apache.s2graph.core.utils.{DeferCache, Extensions, logger}
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies
+import org.apache.tinkerpop.gremlin.process.traversal.{P, TraversalStrategies}
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer
 import org.apache.tinkerpop.gremlin.structure.{Direction, Edge, Graph}
 
 import scala.collection.JavaConversions._
@@ -58,7 +59,7 @@ object S2Graph {
     "hbase.table.name" -> "s2graph",
     "hbase.table.compression.algorithm" -> "gz",
     "phase" -> "dev",
-    "db.default.driver" ->  "org.h2.Driver",
+    "db.default.driver" -> "org.h2.Driver",
     "db.default.url" -> "jdbc:h2:file:./var/metastore;MODE=MYSQL",
     "db.default.password" -> "graph",
     "db.default.user" -> "graph",
@@ -110,7 +111,7 @@ object S2Graph {
     } {
       m.put(key, value)
     }
-    val config  = ConfigFactory.parseMap(m).withFallback(DefaultConfig)
+    val config = ConfigFactory.parseMap(m).withFallback(DefaultConfig)
     config
   }
 
@@ -134,7 +135,7 @@ object S2Graph {
 
     storageBackend match {
       case "hbase" =>
-        hbaseExecutor  =
+        hbaseExecutor =
           if (config.getString("hbase.zookeeper.quorum") == "localhost")
             AsynchbaseStorage.initLocalHBase(config)
           else
@@ -176,7 +177,9 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
 
   override val config = _config.withFallback(S2Graph.DefaultConfig)
 
-  val storageBackend = Try { config.getString("s2graph.storage.backend") }.getOrElse("hbase")
+  val storageBackend = Try {
+    config.getString("s2graph.storage.backend")
+  }.getOrElse("hbase")
 
   Model.apply(config)
   Model.loadCache()
@@ -260,6 +263,15 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
       localLongId.set(0l)
     }
 
+  def searchVertices(queryParam: VertexQueryParam): Future[Seq[S2VertexLike]] = {
+    val matchedVertices = indexProvider.fetchVertexIdsAsyncRaw(queryParam).map { vids =>
+      (queryParam.vertexIds ++ vids).distinct.map(vid => elementBuilder.newVertex(vid))
+    }
+
+    if (queryParam.fetchProp) matchedVertices.flatMap(getVertices)
+    else matchedVertices
+  }
+
   override def getVertices(vertices: Seq[S2VertexLike]): Future[Seq[S2VertexLike]] = {
     val verticesWithIdx = vertices.zipWithIndex
     val futures = verticesWithIdx.groupBy { case (v, idx) => v.service }.map { case (service, vertexGroup) =>
@@ -289,7 +301,9 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
   override def mutateVertices(vertices: Seq[S2VertexLike], withWait: Boolean = false): Future[Seq[MutateResponse]] = {
     def mutateVertices(storage: Storage)(zkQuorum: String, vertices: Seq[S2VertexLike],
                                          withWait: Boolean = false): Future[Seq[MutateResponse]] = {
-      val futures = vertices.map { vertex => storage.mutateVertex(zkQuorum, vertex, withWait) }
+      val futures = vertices.map { vertex =>
+        storage.mutateVertex(zkQuorum, vertex, withWait)
+      }
       Future.sequence(futures)
     }
 
@@ -297,7 +311,12 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
     val futures = verticesWithIdx.groupBy { case (v, idx) => v.service }.map { case (service, vertexGroup) =>
       mutateVertices(getStorage(service))(service.cluster, vertexGroup.map(_._1), withWait).map(_.zip(vertexGroup.map(_._2)))
     }
-    Future.sequence(futures).map { ls => ls.flatten.toSeq.sortBy(_._2).map(_._1) }
+
+    Future.sequence(futures).flatMap { ls =>
+      indexProvider.mutateVerticesAsync(vertices).map { _ =>
+        ls.flatten.toSeq.sortBy(_._2).map(_._1)
+      }
+    }
   }
 
   override def mutateEdges(edges: Seq[S2EdgeLike], withWait: Boolean = false): Future[Seq[MutateResponse]] = {

--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -268,7 +268,7 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
       (queryParam.vertexIds ++ vids).distinct.map(vid => elementBuilder.newVertex(vid))
     }
 
-    if (queryParam.fetchProp) matchedVertices.flatMap(getVertices)
+    if (true) matchedVertices.flatMap(vs => getVertices(vs))
     else matchedVertices
   }
 
@@ -312,10 +312,9 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
       mutateVertices(getStorage(service))(service.cluster, vertexGroup.map(_._1), withWait).map(_.zip(vertexGroup.map(_._2)))
     }
 
-    Future.sequence(futures).flatMap { ls =>
-      indexProvider.mutateVerticesAsync(vertices).map { _ =>
-        ls.flatten.toSeq.sortBy(_._2).map(_._1)
-      }
+    indexProvider.mutateVerticesAsync(vertices)
+    Future.sequence(futures).map{ ls =>
+      ls.flatten.toSeq.sortBy(_._2).map(_._1)
     }
   }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -476,6 +476,7 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
     val futures = edgesWithIdx.groupBy { case (e, idx) => e.innerLabel }.map { case (label, edgeGroup) =>
       getStorage(label).incrementCounts(label.hbaseZkAddr, edgeGroup.map(_._1), withWait).map(_.zip(edgeGroup.map(_._2)))
     }
+
     Future.sequence(futures).map { ls =>
       ls.flatten.toSeq.sortBy(_._2).map(_._1)
     }

--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -268,7 +268,7 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
       (queryParam.vertexIds ++ vids).distinct.map(vid => elementBuilder.newVertex(vid))
     }
 
-    if (true) matchedVertices.flatMap(vs => getVertices(vs))
+    if (queryParam.fetchProp) matchedVertices.flatMap(vs => getVertices(vs))
     else matchedVertices
   }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/IndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/IndexProvider.scala
@@ -121,6 +121,7 @@ trait IndexProvider {
 
   def fetchVertexIds(hasContainers: java.util.List[HasContainer]): java.util.List[VertexId]
   def fetchVertexIdsAsync(hasContainers: java.util.List[HasContainer]): Future[java.util.List[VertexId]]
+  def fetchVertexIdsAsyncRaw(vertexQueryParam: VertexQueryParam): Future[java.util.List[VertexId]] = Future.successful(util.Arrays.asList())
 
   def mutateVertices(vertices: Seq[S2VertexLike], forceToIndex: Boolean = false): Seq[Boolean]
   def mutateVerticesAsync(vertices: Seq[S2VertexLike], forceToIndex: Boolean = false): Future[Seq[Boolean]]

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/IndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/IndexProvider.scala
@@ -35,8 +35,6 @@ import scala.util.Try
 
 object IndexProvider {
   import GlobalIndex._
-  //TODO: Fix Me
-  val hitsPerPage = 100000
   val IdField = "id"
 
   def apply(config: Config)(implicit ec: ExecutionContext): IndexProvider = {

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
@@ -23,6 +23,7 @@ import java.io.File
 import java.util
 
 import com.typesafe.config.Config
+import org.apache.lucene.analysis.core.KeywordAnalyzer
 import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.document.{Document, Field, StringField}
 import org.apache.lucene.index.{DirectoryReader, IndexWriter, IndexWriterConfig, Term}
@@ -48,7 +49,7 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
   import scala.collection.JavaConverters._
   import scala.collection.mutable
 
-  val analyzer = new StandardAnalyzer()
+  val analyzer = new KeywordAnalyzer()
   val writers = mutable.Map.empty[String, IndexWriter]
   val directories = mutable.Map.empty[String, BaseDirectory]
   val baseDirectory = scala.util.Try(config.getString("index.provider.base.dir")).getOrElse(".")
@@ -174,11 +175,11 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
       val searcher = new IndexSearcher(reader)
 
       val docs = searcher.search(q, hitsPerPage)
-      logger.error(s"total hit: ${docs.scoreDocs.length}")
+//      logger.error(s"total hit: ${docs.scoreDocs.length}")
 
       docs.scoreDocs.foreach { scoreDoc =>
         val document = searcher.doc(scoreDoc.doc)
-        logger.error(s"DOC_IN_L: ${document.toString}")
+//        logger.error(s"DOC_IN_L: ${document.toString}")
 
         val id = reads.reads(Json.parse(document.get(field))).get
         ids.add(id)

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
@@ -56,8 +56,16 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
   val MAX_RESULTS = 100000
 
   private def getOrElseDirectory(indexName: String): BaseDirectory = {
-    val pathname = s"${baseDirectory}/${indexName}"
-    val dir = directories.getOrElseUpdate(indexName, new SimpleFSDirectory(new File(pathname).toPath))
+    val fsType = scala.util.Try(config.getString("index.provider.lucene.fsType")).getOrElse("memory")
+
+    val fsDir = if (fsType == "memory") {
+      new RAMDirectory()
+    } else {
+      val pathname = s"${baseDirectory}/${indexName}"
+      new SimpleFSDirectory(new File(pathname).toPath)
+    }
+
+    val dir = directories.getOrElseUpdate(indexName, fsDir)
 
     dir
   }

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
@@ -19,6 +19,7 @@
 
 package org.apache.s2graph.core.index
 
+import java.io.File
 import java.util
 
 import com.typesafe.config.Config
@@ -26,20 +27,21 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.document.{Document, Field, StringField}
 import org.apache.lucene.index.{DirectoryReader, IndexWriter, IndexWriterConfig, Term}
 import org.apache.lucene.queryparser.classic.{ParseException, QueryParser}
-import org.apache.lucene.search.IndexSearcher
-import org.apache.lucene.store.{BaseDirectory, RAMDirectory}
+import org.apache.lucene.search.{IndexSearcher, Query}
+import org.apache.lucene.store.{BaseDirectory, RAMDirectory, SimpleFSDirectory}
 import org.apache.s2graph.core.io.Conversions
 import org.apache.s2graph.core.mysqls.GlobalIndex
 import org.apache.s2graph.core.types.VertexId
 import org.apache.s2graph.core.utils.logger
-import org.apache.s2graph.core.{EdgeId, S2EdgeLike, S2VertexLike}
+import org.apache.s2graph.core.{EdgeId, S2EdgeLike, S2VertexLike, VertexQueryParam}
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 import scala.concurrent.Future
 
 
 class LuceneIndexProvider(config: Config) extends IndexProvider {
+
   import GlobalIndex._
   import IndexProvider._
 
@@ -49,10 +51,19 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
   val analyzer = new StandardAnalyzer()
   val writers = mutable.Map.empty[String, IndexWriter]
   val directories = mutable.Map.empty[String, BaseDirectory]
+  val baseDirectory = scala.util.Try(config.getString("index.provider.base.dir")).getOrElse(".")
+
+  private def getOrElseDirectory(indexName: String): BaseDirectory = {
+    val pathname = s"${baseDirectory}/${indexName}"
+    val dir = directories.getOrElseUpdate(indexName, new SimpleFSDirectory(new File(pathname).toPath))
+
+    dir
+  }
 
   private def getOrElseCreateIndexWriter(indexName: String): IndexWriter = {
     writers.getOrElseUpdate(indexName, {
-      val dir = directories.getOrElseUpdate(indexName, new RAMDirectory())
+      val dir = getOrElseDirectory(indexName)
+
       val indexConfig = new IndexWriterConfig(analyzer)
       new IndexWriter(dir, indexConfig)
     })
@@ -124,8 +135,9 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
     vertices.foreach { vertex =>
       toDocument(vertex, forceToIndex).foreach { doc =>
         val vId = vertex.id.toString()
+//        logger.error(s"DOC: ${doc}")
 
-        writer.updateDocument(new Term(IdField, vId), doc)
+        writer.updateDocument(new Term(vidField, vId), doc)
       }
     }
 
@@ -144,7 +156,7 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
       toDocument(edge, forceToIndex).foreach { doc =>
         val eId = edge.edgeId.toString
 
-        writer.updateDocument(new Term(IdField, eId), doc)
+        writer.updateDocument(new Term(eidField, eId), doc)
       }
     }
 
@@ -153,73 +165,84 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
     edges.map(_ => true)
   }
 
-  override def fetchEdgeIds(hasContainers: java.util.List[HasContainer]): java.util.List[EdgeId] = {
-    val field = eidField
-    val ids = new java.util.HashSet[EdgeId]
-
-    val queryString = buildQueryString(hasContainers)
+  private def fetchInner[T](q: Query, indexKey: String, field: String, reads: Reads[T]): util.List[T] = {
+    val ids = new java.util.HashSet[T]
+    var reader: DirectoryReader = null
 
     try {
-      val q = new QueryParser(field, analyzer).parse(queryString)
-
-      val reader = DirectoryReader.open(directories(GlobalIndex.EdgeIndexName))
+      val reader = DirectoryReader.open(getOrElseDirectory(indexKey))
       val searcher = new IndexSearcher(reader)
 
       val docs = searcher.search(q, hitsPerPage)
+      logger.error(s"total hit: ${docs.scoreDocs.length}")
 
       docs.scoreDocs.foreach { scoreDoc =>
         val document = searcher.doc(scoreDoc.doc)
-        val id = Conversions.s2EdgeIdReads.reads(Json.parse(document.get(field))).get
-        ids.add(id);
-      }
+        logger.error(s"DOC_IN_L: ${document.toString}")
 
-      reader.close()
-      ids
+        val id = reads.reads(Json.parse(document.get(field))).get
+        ids.add(id)
+      }
     } catch {
-      case ex: ParseException =>
-        logger.error(s"[IndexProvider]: ${queryString} parse failed.", ex)
-        ids
+      case e: org.apache.lucene.index.IndexNotFoundException => logger.info("Index file not found.")
+    } finally {
+      if (reader != null) reader.close()
     }
 
-    new util.ArrayList[EdgeId](ids)
+    new util.ArrayList[T](ids)
   }
 
   override def fetchVertexIds(hasContainers: java.util.List[HasContainer]): java.util.List[VertexId] = {
     val field = vidField
-    val ids = new java.util.HashSet[VertexId]
     val queryString = buildQueryString(hasContainers)
 
     try {
       val q = new QueryParser(field, analyzer).parse(queryString)
-
-      val reader = DirectoryReader.open(directories(GlobalIndex.VertexIndexName))
-      val searcher = new IndexSearcher(reader)
-
-      val docs = searcher.search(q, hitsPerPage)
-
-      docs.scoreDocs.foreach { scoreDoc =>
-        val document = searcher.doc(scoreDoc.doc)
-        val id = Conversions.s2VertexIdReads.reads(Json.parse(document.get(field))).get
-        ids.add(id)
-      }
-
-      reader.close()
-      ids
+      fetchInner[VertexId](q, GlobalIndex.VertexIndexName, vidField, Conversions.s2VertexIdReads)
     } catch {
       case ex: ParseException =>
         logger.error(s"[IndexProvider]: ${queryString} parse failed.", ex)
-        ids
+        util.Arrays.asList[VertexId]()
+    }
+  }
+
+  override def fetchEdgeIds(hasContainers: java.util.List[HasContainer]): java.util.List[EdgeId] = {
+    val field = eidField
+    val queryString = buildQueryString(hasContainers)
+
+    try {
+      val q = new QueryParser(field, analyzer).parse(queryString)
+      fetchInner[EdgeId](q, GlobalIndex.EdgeIndexName, field, Conversions.s2EdgeIdReads)
+    } catch {
+      case ex: ParseException =>
+        logger.error(s"[IndexProvider]: ${queryString} parse failed.", ex)
+        util.Arrays.asList[EdgeId]()
+    }
+  }
+
+  override def fetchEdgeIdsAsync(hasContainers: java.util.List[HasContainer]): Future[util.List[EdgeId]] = Future.successful(fetchEdgeIds(hasContainers))
+
+  override def fetchVertexIdsAsync(hasContainers: java.util.List[HasContainer]): Future[util.List[VertexId]] = Future.successful(fetchVertexIds(hasContainers))
+
+  override def fetchVertexIdsAsyncRaw(vertexQueryParam: VertexQueryParam): Future[util.List[VertexId]] = {
+    val ret = vertexQueryParam.searchString.fold(util.Arrays.asList[VertexId]()) { queryString =>
+      val field = vidField
+      try {
+        val q = new QueryParser(field, analyzer).parse(queryString)
+        fetchInner[VertexId](q, GlobalIndex.VertexIndexName, vidField, Conversions.s2VertexIdReads)
+      } catch {
+        case ex: ParseException =>
+          logger.error(s"[IndexProvider]: ${queryString} parse failed.", ex)
+          util.Arrays.asList[VertexId]()
+      }
     }
 
-    new util.ArrayList[VertexId](ids)
+    Future.successful(ret)
   }
 
   override def shutdown(): Unit = {
     writers.foreach { case (_, writer) => writer.close() }
   }
 
-  override def fetchEdgeIdsAsync(hasContainers: java.util.List[HasContainer]): Future[util.List[EdgeId]] = Future.successful(fetchEdgeIds(hasContainers))
-
-  override def fetchVertexIdsAsync(hasContainers: java.util.List[HasContainer]): Future[util.List[VertexId]] = Future.successful(fetchVertexIds(hasContainers))
 }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/rest/RequestParser.scala
@@ -229,7 +229,7 @@ class RequestParser(graph: S2GraphLike) {
           override def call(): Try[Where] = {
             val _where = TemplateHelper.replaceVariable(System.currentTimeMillis(), where)
 
-            WhereParser(label).parse(_where) match {
+            WhereParser().parse(_where) match {
               case s@Success(_) => s
               case Failure(ex) => throw BadQueryException(ex.getMessage, ex)
             }

--- a/s2core/src/test/scala/org/apache/s2graph/core/Integrate/QueryTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/Integrate/QueryTest.scala
@@ -72,7 +72,7 @@ class QueryTest extends IntegrateCommon with BeforeAndAfterEach {
     Query(
       vertices = Seq(graph.toVertex(testServiceName, testColumnName, id)),
       steps = Vector(
-        Step(Seq(QueryParam(testLabelName, where = Where(testLabelName, where))))
+        Step(Seq(QueryParam(testLabelName, where = Where(where))))
       )
     )
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/index/IndexProviderTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/index/IndexProviderTest.scala
@@ -29,6 +29,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper
 import org.apache.tinkerpop.gremlin.structure.T
 
 import scala.collection.JavaConversions._
+import scala.concurrent._
+import scala.concurrent.duration._
 
 class IndexProviderTest extends IntegrateCommon {
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -74,14 +76,19 @@ class IndexProviderTest extends IntegrateCommon {
     Thread.sleep(1000)
 
     (0 until numOfTry).foreach { ith =>
-      val hasContainer = new HasContainer(indexPropsColumnMeta.name, P.eq(Long.box(1)))
+//      val hasContainer = new HasContainer(indexPropsColumnMeta.name, P.eq(Long.box(1)))
+      val hasContainer = new HasContainer(GlobalIndex.serviceColumnField, P.eq(testColumn.columnName))
 
-      var ids = indexProvider.fetchVertexIds(Seq(hasContainer))
-      ids.head shouldBe vertex.id
+      val f = graph.searchVertices(VertexQueryParam(0, 100, Option(s"${GlobalIndex.serviceColumnField}:${testColumn.columnName}")))
+      val a = Await.result(f, Duration("60 sec"))
+      println(a)
 
-      ids.foreach { id =>
-        println(s"[Id]: $id")
-      }
+//      var ids = indexProvider.fetchVertexIds(Seq(hasContainer))
+//      ids.head shouldBe vertex.id
+//
+//      ids.foreach { id =>
+//        println(s"[Id]: $id")
+//      }
     }
   }
 

--- a/s2core/src/test/scala/org/apache/s2graph/core/parsers/WhereParserTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/parsers/WhereParserTest.scala
@@ -45,7 +45,7 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
       println("==================")
     }
 
-    val whereOpt = WhereParser(label).parse(sql)
+    val whereOpt = WhereParser().parse(sql)
     if (whereOpt.isFailure) {
       debug(whereOpt)
       whereOpt.get // touch exception
@@ -285,4 +285,13 @@ class WhereParserTest extends FunSuite with Matchers with TestCommonWithModels {
       r >= 10 && r < 30
     }
   }
+
+  test("check parse contains") {
+    val dummyLabel = ids.head._3
+
+    val sql = "name = 'daewon'"
+    val whereOpt = WhereParser().parse(sql)
+    println(whereOpt)
+  }
+
 }

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
@@ -41,15 +41,14 @@ object GraphRepository {
   }
 
   implicit val edgeHasId = new HasId[(S2VertexLike, QueryParam, Seq[S2EdgeLike]), DeferFetchEdges] {
-    override def id(value: (S2VertexLike, QueryParam, Seq[S2EdgeLike])): DeferFetchEdges =
-      DeferFetchEdges(value._1, value._2)
+    override def id(value: (S2VertexLike, QueryParam, Seq[S2EdgeLike])): DeferFetchEdges = DeferFetchEdges(value._1, value._2)
   }
 
   val vertexFetcher =
-    Fetcher((ctx: GraphRepository, ids: Seq[VertexQueryParam]) => {
+    Fetcher((ctx: GraphRepository, queryParams: Seq[VertexQueryParam]) => {
       implicit val ec = ctx.ec
 
-      Future.traverse(ids)(ctx.getVertices).map(vs => ids.zip(vs))
+      Future.traverse(queryParams)(ctx.getVertices).map(vs => queryParams.zip(vs))
     })
 
   val edgeFetcher = Fetcher((ctx: GraphRepository, ids: Seq[DeferFetchEdges]) => {

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
@@ -126,7 +126,10 @@ class GraphRepository(val graph: S2GraphLike) {
   }
 
   def getVertices(queryParam: VertexQueryParam): Future[Seq[S2VertexLike]] = {
-    graph.asInstanceOf[S2Graph].searchVertices(queryParam)
+    graph.asInstanceOf[S2Graph].searchVertices(queryParam).map { a =>
+      println(a)
+      a
+    }
   }
 
   def getEdges(vertices: Seq[S2VertexLike], queryParam: QueryParam): Future[Seq[S2EdgeLike]] = {

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
@@ -4,6 +4,7 @@ import org.apache.s2graph.core._
 import org.apache.s2graph.core.mysqls._
 import org.apache.s2graph.graphql.bind.AstHelper
 import org.apache.s2graph.graphql.repository.GraphRepository
+import org.apache.s2graph.graphql.types.S2Type.EdgeQueryParam
 import sangria.schema._
 
 object FieldResolver {
@@ -28,7 +29,7 @@ object FieldResolver {
     }
   }
 
-  def label(label: Label, c: Context[GraphRepository, Any]): (S2VertexLike, QueryParam) = {
+  def label(label: Label, c: Context[GraphRepository, Any]): EdgeQueryParam = {
     val vertex = c.value.asInstanceOf[S2VertexLike]
 
     val dir = c.arg[String]("direction")
@@ -46,7 +47,7 @@ object FieldResolver {
       where = where
     )
 
-    (vertex, qp)
+    EdgeQueryParam(vertex, qp)
   }
 
   def serviceColumnOnService(column: ServiceColumn, c: Context[GraphRepository, Any]): VertexQueryParam = {

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
@@ -53,6 +53,8 @@ object FieldResolver {
     val ids = c.argOpt[Any]("id").toSeq ++ c.argOpt[List[Any]]("ids").toList.flatten
     val vertices = ids.map(vid => c.ctx.toS2VertexLike(vid, column))
 
+    val search = c.argOpt[String]("search")
+
     val columnFields = column.metasInvMap.keySet
     val selectedFields = AstHelper.selectedFields(c.astFields)
 

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
@@ -53,8 +53,6 @@ object FieldResolver {
     val ids = c.argOpt[Any]("id").toSeq ++ c.argOpt[List[Any]]("ids").toList.flatten
     val vertices = ids.map(vid => c.ctx.toS2VertexLike(vid, column))
 
-    val search = c.argOpt[String]("search")
-
     val columnFields = column.metasInvMap.keySet
     val selectedFields = AstHelper.selectedFields(c.astFields)
 

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2Type.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2Type.scala
@@ -19,21 +19,19 @@
 
 package org.apache.s2graph.graphql.types
 
-import scala.concurrent._
-import org.apache.s2graph.core.Management.JsonModel.{Index, Prop}
+import org.apache.s2graph.core.Management.JsonModel._
 import org.apache.s2graph.core._
 import org.apache.s2graph.core.mysqls._
 import org.apache.s2graph.graphql
 import org.apache.s2graph.graphql.repository.GraphRepository
 import sangria.schema._
-import org.apache.s2graph.graphql.bind.AstHelper
-import org.apache.s2graph.graphql.repository
-import org.apache.s2graph.graphql.repository.GraphRepository.DeferFetchEdges
 import org.apache.s2graph.graphql.types.StaticTypes._
 
 import scala.language.existentials
 
 object S2Type {
+
+  case class EdgeQueryParam(v: S2VertexLike, qp: QueryParam)
 
   case class AddVertexParam(timestamp: Long,
                             id: Any,
@@ -215,11 +213,10 @@ object S2Type {
       resolve = { c =>
         implicit val ec = c.ctx.ec
 
-        val (vertex, queryParam) = graphql.types.FieldResolver.label(label, c)
-        val de = DeferFetchEdges(vertex, queryParam)
+        val edgeQueryParam = graphql.types.FieldResolver.label(label, c)
         val empty = Seq.empty[S2EdgeLike]
 
-        DeferredValue(GraphRepository.edgeFetcher.deferOpt(de)).map(m => m.fold(empty)(_._3))
+        DeferredValue(GraphRepository.edgeFetcher.deferOpt(edgeQueryParam)).map(m => m.fold(empty)(_._2))
       }
     )
 


### PR DESCRIPTION
# Added the ability to search for the value of a vertex properties

You can use the 'apache [lucene](https://lucene.apache.org) query' directly in the 'search' parameter to search vertex by property values

example)

{noformat}
```graphql
{
  kakao {
    user(search: "gender: M OR gender: F") {
      id
      age
      gender
    }
  }
}
```
{noformat}

{noformat}
```graphql
{
  kakao {
    user(search: "age: 19 OR age: 20") {
      id
      age
      gender
    }
  }
}
```
{noformat}

