### PR TITLE
[S2GRAPH-209] GlobalIndex supports field data types such as Numeric to enable Range Query.

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/QueryParam.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/QueryParam.scala
@@ -293,6 +293,10 @@ object QueryParam {
   }
 }
 
+object VertexQueryParam {
+  def Empty: VertexQueryParam = VertexQueryParam(0, 1, None)
+}
+
 case class VertexQueryParam(offset: Int,
                             limit: Int,
                             searchString: Option[String],

--- a/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/index/LuceneIndexProvider.scala
@@ -183,7 +183,7 @@ class LuceneIndexProvider(config: Config) extends IndexProvider {
       val reader = DirectoryReader.open(getOrElseDirectory(indexKey))
       val searcher = new IndexSearcher(reader)
       val collector = TopScoreDocCollector.create(MAX_RESULTS)
-      val startIndex = offset * limit
+      val startIndex = offset
 
       searcher.search(q, collector)
 

--- a/s2graphql/src/test/scala/org/apache/s2graph/graphql/ScenarioTest.scala
+++ b/s2graphql/src/test/scala/org/apache/s2graph/graphql/ScenarioTest.scala
@@ -437,6 +437,31 @@ class ScenarioTest extends FunSpec with Matchers with BeforeAndAfterAll {
         actual shouldBe expected
       }
 
+      it("should fetch vertices: offset, limit") {
+        val query =
+          graphql"""
+
+          query FetchVertices {
+            kakao {
+              user(search: "gender: M OR gender: F or gender: T", offset: 1, limit: 2) {
+                id
+                age
+                gender
+                props {
+                  age
+                }
+              }
+            }
+          }
+        """
+
+        val actual = testGraph.queryAsJs(query)
+        val expected = 2
+
+        // The user order may vary depending on the indexProvider(es, lucene).
+        (actual \\ "gender").size shouldBe expected
+      }
+
       it("should fetch vertices using VertexIndex: 'gender in (F, M)') from kakao.user") {
         def query(search: String) = {
           QueryParser.parse(


### PR DESCRIPTION
First implemented a range query in 'elasticsearch' and applied VertexQueryParam(offset, limit).
