### PR TITLE
[S2GRAPH-215] Implement a Storage Backend for JDBC driver, such as H2, MySql using the Mutator and Fetcher interfaces.

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/EdgeFetcher.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/EdgeFetcher.scala
@@ -24,7 +24,7 @@ import org.apache.s2graph.core.types.VertexId
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait EdgeFetcher {
+trait EdgeFetcher extends AutoCloseable {
 
   def init(config: Config)(implicit ec: ExecutionContext): Unit = {}
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/EdgeMutator.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/EdgeMutator.scala
@@ -24,7 +24,7 @@ import org.apache.s2graph.core.storage.MutateResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait EdgeMutator {
+trait EdgeMutator extends AutoCloseable {
 
   def mutateStrongEdges(zkQuorum: String, _edges: Seq[S2EdgeLike], withWait: Boolean)(implicit ec: ExecutionContext): Future[Seq[Boolean]]
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/ResourceManager.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/ResourceManager.scala
@@ -19,10 +19,15 @@
 
 package org.apache.s2graph.core
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.impl.ConfigImpl
+import com.typesafe.config._
 import org.apache.s2graph.core.schema.{Label, ServiceColumn}
-import org.apache.s2graph.core.utils.SafeUpdateCache
+import org.apache.s2graph.core.utils.{SafeUpdateCache, logger}
+
 import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+import scala.tools.nsc.typechecker.StructuredTypeStrings
+import scala.util.Try
 
 
 object ResourceManager {
@@ -32,14 +37,19 @@ object ResourceManager {
   import scala.collection.JavaConverters._
 
   val ClassNameKey = "className"
-  val EdgeFetcherKey = classOf[EdgeFetcher].getClass().getName
+  val MaxSizeKey = "resource.cache.max.size"
+  val CacheTTL = "resource.cache.ttl.seconds"
 
-  val VertexFetcherKey = classOf[VertexFetcher].getClass().getName
+  val EdgeFetcherKey = classOf[EdgeFetcher].getName
 
-  val EdgeMutatorKey = classOf[EdgeMutator].getClass.getName
-  val VertexMutatorKey = classOf[VertexMutator].getClass.getName
+  val VertexFetcherKey = classOf[VertexFetcher].getName
 
-  val DefaultConfig = ConfigFactory.parseMap(Map(MaxSizeKey -> 1000, TtlKey -> -1).asJava)
+  val EdgeMutatorKey = classOf[EdgeMutator].getName
+  val VertexMutatorKey = classOf[VertexMutator].getName
+
+  val DefaultMaxSize = 1000
+  val DefaultCacheTTL = -1
+  val DefaultConfig = ConfigFactory.parseMap(Map(MaxSizeKey -> DefaultMaxSize, TtlKey -> DefaultCacheTTL).asJava)
 }
 
 class ResourceManager(graph: S2GraphLike,
@@ -49,7 +59,10 @@ class ResourceManager(graph: S2GraphLike,
 
   import scala.collection.JavaConverters._
 
-  val cache = new SafeUpdateCache(_config)
+  val maxSize = Try(_config.getInt(ResourceManager.MaxSizeKey)).getOrElse(DefaultMaxSize)
+  val cacheTTL = Try(_config.getInt(ResourceManager.CacheTTL)).getOrElse(DefaultCacheTTL)
+
+  val cache = new SafeUpdateCache(maxSize, cacheTTL)
 
   def getAllVertexFetchers(): Seq[VertexFetcher] = {
     cache.asMap().asScala.toSeq.collect { case (_, (obj: VertexFetcher, _, _)) => obj }
@@ -59,10 +72,22 @@ class ResourceManager(graph: S2GraphLike,
     cache.asMap().asScala.toSeq.collect { case (_, (obj: EdgeFetcher, _, _)) => obj }
   }
 
+  def onEvict(oldValue: AnyRef): Unit = {
+    oldValue match {
+      case o: Option[_] => o.foreach {
+        case v: AutoCloseable => v.close()
+      }
+      case v: AutoCloseable => v.close()
+      case _ => logger.info(s"Class does't have close() method ${oldValue.getClass.getName}")
+    }
+
+    logger.info(s"[${oldValue.getClass.getName}]: $oldValue evicted.")
+  }
+
   def getOrElseUpdateVertexFetcher(column: ServiceColumn,
                                    cacheTTLInSecs: Option[Int] = None): Option[VertexFetcher] = {
     val cacheKey = VertexFetcherKey + "_" + column.service.serviceName + "_" + column.columnName
-    cache.withCache(cacheKey, false, cacheTTLInSecs) {
+    cache.withCache(cacheKey, false, cacheTTLInSecs, onEvict) {
       column.toFetcherConfig.map { fetcherConfig =>
         val className = fetcherConfig.getString(ClassNameKey)
         val fetcher = Class.forName(className)
@@ -81,7 +106,7 @@ class ResourceManager(graph: S2GraphLike,
                                  cacheTTLInSecs: Option[Int] = None): Option[EdgeFetcher] = {
     val cacheKey = EdgeFetcherKey + "_" + label.label
 
-    cache.withCache(cacheKey, false, cacheTTLInSecs) {
+    cache.withCache(cacheKey, false, cacheTTLInSecs, onEvict) {
       label.toFetcherConfig.map { fetcherConfig =>
         val className = fetcherConfig.getString(ClassNameKey)
         val fetcher = Class.forName(className)
@@ -89,7 +114,10 @@ class ResourceManager(graph: S2GraphLike,
           .newInstance(graph)
           .asInstanceOf[EdgeFetcher]
 
-        fetcher.init(fetcherConfig)
+        fetcher.init(
+          fetcherConfig
+            .withValue("labelName", ConfigValueFactory.fromAnyRef(label.label))
+        )
 
         fetcher
       }
@@ -99,7 +127,7 @@ class ResourceManager(graph: S2GraphLike,
   def getOrElseUpdateVertexMutator(column: ServiceColumn,
                                    cacheTTLInSecs: Option[Int] = None): Option[VertexMutator] = {
     val cacheKey = VertexMutatorKey + "_" + column.service.serviceName + "_" + column.columnName
-    cache.withCache(cacheKey, false, cacheTTLInSecs) {
+    cache.withCache(cacheKey, false, cacheTTLInSecs, onEvict) {
       column.toMutatorConfig.map { mutatorConfig =>
         val className = mutatorConfig.getString(ClassNameKey)
         val fetcher = Class.forName(className)
@@ -117,7 +145,7 @@ class ResourceManager(graph: S2GraphLike,
   def getOrElseUpdateEdgeMutator(label: Label,
                                  cacheTTLInSecs: Option[Int] = None): Option[EdgeMutator] = {
     val cacheKey = EdgeMutatorKey + "_" + label.label
-    cache.withCache(cacheKey, false, cacheTTLInSecs) {
+    cache.withCache(cacheKey, false, cacheTTLInSecs, onEvict) {
       label.toMutatorConfig.map { mutatorConfig =>
         val className = mutatorConfig.getString(ClassNameKey)
         val fetcher = Class.forName(className)
@@ -125,7 +153,10 @@ class ResourceManager(graph: S2GraphLike,
           .newInstance(graph)
           .asInstanceOf[EdgeMutator]
 
-        fetcher.init(mutatorConfig)
+        fetcher.init(
+          mutatorConfig
+            .withValue("labelName", ConfigValueFactory.fromAnyRef(label.label))
+        )
 
         fetcher
       }

--- a/s2core/src/main/scala/org/apache/s2graph/core/ResourceManager.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/ResourceManager.scala
@@ -74,14 +74,17 @@ class ResourceManager(graph: S2GraphLike,
 
   def onEvict(oldValue: AnyRef): Unit = {
     oldValue match {
-      case o: Option[_] => o.foreach {
-        case v: AutoCloseable => v.close()
+      case o: Option[_] => o.foreach { case v: AutoCloseable =>
+        v.close()
+        logger.info(s"[${oldValue.getClass.getName}]: $oldValue evicted.")
       }
-      case v: AutoCloseable => v.close()
+
+      case v: AutoCloseable =>
+        v.close()
+        logger.info(s"[${oldValue.getClass.getName}]: $oldValue evicted.")
+
       case _ => logger.info(s"Class does't have close() method ${oldValue.getClass.getName}")
     }
-
-    logger.info(s"[${oldValue.getClass.getName}]: $oldValue evicted.")
   }
 
   def getOrElseUpdateVertexFetcher(column: ServiceColumn,

--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -63,6 +63,8 @@ object S2Graph {
     "db.default.user" -> "graph",
     "cache.max.size" -> java.lang.Integer.valueOf(0),
     "cache.ttl.seconds" -> java.lang.Integer.valueOf(-1),
+    "resource.cache.max.size" -> java.lang.Integer.valueOf(1000),
+    "resource.cache.ttl.seconds" -> java.lang.Integer.valueOf(-1),
     "hbase.client.retries.number" -> java.lang.Integer.valueOf(20),
     "hbase.rpcs.buffered_flush_interval" -> java.lang.Short.valueOf(100.toShort),
     "hbase.rpc.timeout" -> java.lang.Integer.valueOf(600000),
@@ -282,12 +284,12 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
   *  right implementation(S2GRAPH-213).
   * */
   override def getVertexFetcher(column: ServiceColumn): VertexFetcher = {
-    resourceManager.getOrElseUpdateVertexFetcher(column)
+    resourceManager.getOrElseUpdateVertexFetcher(column, Option(60 * 60 * 24))
       .getOrElse(defaultStorage.vertexFetcher)
   }
 
   override def getEdgeFetcher(label: Label): EdgeFetcher = {
-    resourceManager.getOrElseUpdateEdgeFetcher(label)
+    resourceManager.getOrElseUpdateEdgeFetcher(label, Option(60 * 60 * 24))
       .getOrElse(defaultStorage.edgeFetcher)
   }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/S2Graph.scala
@@ -284,12 +284,12 @@ class S2Graph(_config: Config)(implicit val ec: ExecutionContext) extends S2Grap
   *  right implementation(S2GRAPH-213).
   * */
   override def getVertexFetcher(column: ServiceColumn): VertexFetcher = {
-    resourceManager.getOrElseUpdateVertexFetcher(column, Option(60 * 60 * 24))
+    resourceManager.getOrElseUpdateVertexFetcher(column)
       .getOrElse(defaultStorage.vertexFetcher)
   }
 
   override def getEdgeFetcher(label: Label): EdgeFetcher = {
-    resourceManager.getOrElseUpdateEdgeFetcher(label, Option(60 * 60 * 24))
+    resourceManager.getOrElseUpdateEdgeFetcher(label)
       .getOrElse(defaultStorage.edgeFetcher)
   }
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/VertexFetcher.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/VertexFetcher.scala
@@ -24,7 +24,7 @@ import org.apache.s2graph.core.types.VertexId
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait VertexFetcher {
+trait VertexFetcher extends AutoCloseable {
   def init(config: Config)(implicit ec: ExecutionContext): Unit = {}
 
   def fetchVertices(vertices: Seq[S2VertexLike])(implicit ec: ExecutionContext): Future[Seq[S2VertexLike]]

--- a/s2core/src/main/scala/org/apache/s2graph/core/VertexMutator.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/VertexMutator.scala
@@ -24,7 +24,7 @@ import org.apache.s2graph.core.storage.MutateResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait VertexMutator {
+trait VertexMutator extends AutoCloseable {
   def close(): Unit = {}
 
   def init(config: Config)(implicit ec: ExecutionContext): Unit = {}

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeFetcher.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeFetcher.scala
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.s2graph.core.storage.jdbc
 
 import com.typesafe.config.Config

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeFetcher.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeFetcher.scala
@@ -1,0 +1,80 @@
+package org.apache.s2graph.core.storage.jdbc
+
+import com.typesafe.config.Config
+import org.apache.s2graph.core.types.VertexId
+import org.apache.s2graph.core._
+import org.apache.s2graph.core.schema.{Label, LabelMeta}
+import scalikejdbc.{ConnectionPool, ConnectionPoolSettings}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scalikejdbc._
+
+class JdbcEdgeFetcher(graph: S2GraphLike) extends EdgeFetcher {
+
+  import JdbcStorage._
+
+  var selectQuery: SQLSyntax = _
+
+  override def init(config: Config)(implicit ec: ExecutionContext): Unit = {
+    import JdbcStorage._
+
+    val labelName = config.getString("labelName")
+    val label = Label.findByName(labelName, useCache = false).get
+
+    selectQuery = SQLSyntax.createUnsafely(
+      s"SELECT ${affectedColumns(label).mkString(", ")} FROM ${labelTableName(label)}"
+    )
+
+    JdbcStorage.prepareConnection(config)
+    createTable(label)
+  }
+
+  def toEdge(metas: Seq[LabelMeta], labelName: String, direction: String, rs: Map[String, Any]): S2EdgeLike = {
+    val from = rs("_from".toUpperCase())
+    val to = rs("_to".toUpperCase())
+    val timestamp = rs("_timestamp".toUpperCase()).asInstanceOf[java.sql.Timestamp].millis
+
+    val props = metas.map { meta =>
+      meta.name -> rs(meta.name.toUpperCase())
+    }.toMap
+
+    if (direction == "out") {
+      graph.toEdge(from, to, labelName, direction, props, timestamp)
+    } else {
+      graph.toEdge(to, from, labelName, direction, props, timestamp)
+    }
+  }
+
+  override def fetches(queryRequests: Seq[QueryRequest], prevStepEdges: Map[VertexId, Seq[EdgeWithScore]])(implicit ec: ExecutionContext): Future[Seq[StepResult]] = {
+    withReadOnlySession { implicit session =>
+      val stepResultLs = queryRequests.map { queryRequest =>
+        val vertex = queryRequest.vertex
+        val queryParam = queryRequest.queryParam
+        val label = queryParam.label
+        val metas = label.metas()
+
+        val limit = queryParam.limit
+        val offset = queryParam.offset
+        val cond = vertex.innerId.toIdString()
+        val orderColumn = SQLSyntax.createUnsafely("_timestamp")
+
+        val rows = if (queryParam.direction == "out") {
+          sql"""${selectQuery} WHERE _from = ${cond} ORDER BY ${orderColumn} DESC offset ${offset} limit ${limit}""".map(Row.apply).list().apply()
+        } else {
+          sql"""${selectQuery} WHERE _to = ${cond} ORDER BY ${orderColumn} DESC offset ${offset} limit ${limit}""".map(Row.apply).list().apply()
+        }
+
+        val edgeWithScores = rows.map { row =>
+          val edge = toEdge(metas, label.label, queryParam.direction, row.row)
+          EdgeWithScore(edge, 1.0, queryParam.label)
+        }
+
+        StepResult(edgeWithScores, Nil, Nil)
+      }
+
+      Future.successful(stepResultLs)
+    }
+  }
+
+  override def fetchEdgesAll()(implicit ec: ExecutionContext): Future[Seq[S2EdgeLike]] = ???
+}

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeMutator.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcEdgeMutator.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.core.storage.jdbc
+
+import com.typesafe.config.Config
+import org.apache.s2graph.core._
+import org.apache.s2graph.core.schema.Label
+import org.apache.s2graph.core.storage.MutateResponse
+import org.joda.time.DateTime
+import scalikejdbc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class JdbcEdgeMutator(graph: S2GraphLike) extends EdgeMutator {
+
+  import JdbcStorage._
+
+  override def init(config: Config)(implicit ec: ExecutionContext): Unit = {
+    val labelName = config.getString("labelName")
+    val label = Label.findByName(labelName, useCache = false).get
+
+    JdbcStorage.prepareConnection(config)
+    createTable(label)
+  }
+
+  override def mutateStrongEdges(zkQuorum: String, _edges: Seq[S2EdgeLike], withWait: Boolean)(implicit ec: ExecutionContext): Future[Seq[Boolean]] = {
+    _edges.groupBy(_.innerLabel).flatMap { case (label, edges) =>
+      val affectedColumns = JdbcStorage.affectedColumns(label)
+
+      val insertValues = edges.map { edge =>
+        val values = affectedColumns.collect {
+          case "_timestamp" => new DateTime(edge.ts)
+          case "_from" => edge.srcForVertex.innerId.value
+          case "_to" => edge.tgtForVertex.innerId.value
+          case k: String => edge.propertyValue(k).map(iv => iv.innerVal.value).orNull
+        }
+
+        values
+      }
+
+      val columns = affectedColumns.mkString(", ")
+      val table = JdbcStorage.labelTableName(label)
+      val prepared = affectedColumns.map(_ => "?").mkString(", ")
+
+      val conflictCheckKeys =
+        if (label.consistencyLevel == "strong") "(_from, _to)"
+        else "(_from, _to, _timestamp)"
+
+      val sqlRaw =
+        s"""MERGE INTO ${table} (${columns}) KEY ${conflictCheckKeys} VALUES (${prepared})""".stripMargin
+
+      val sql = SQLSyntax.createUnsafely(sqlRaw)
+      withTxSession { session =>
+        sql"""${sql}""".batch(insertValues: _*).apply()(session)
+      }
+
+      insertValues
+    }
+
+    Future.successful(_edges.map(_ => true))
+  }
+
+  override def mutateWeakEdges(zkQuorum: String, _edges: Seq[S2EdgeLike], withWait: Boolean)(implicit ec: ExecutionContext): Future[Seq[(Int, Boolean)]] = ???
+
+  override def incrementCounts(zkQuorum: String, edges: Seq[S2EdgeLike], withWait: Boolean)(implicit ec: ExecutionContext): Future[Seq[MutateResponse]] = ???
+
+  override def updateDegree(zkQuorum: String, edge: S2EdgeLike, degreeVal: Long)(implicit ec: ExecutionContext): Future[MutateResponse] = ???
+
+  override def deleteAllFetchedEdgesAsyncOld(stepInnerResult: StepResult, requestTs: Long, retryNum: Int)(implicit ec: ExecutionContext): Future[Boolean] = ???
+}

--- a/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcStorage.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/storage/jdbc/JdbcStorage.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.core.storage.jdbc
+
+import com.typesafe.config.Config
+import org.apache.s2graph.core._
+import org.apache.s2graph.core.schema._
+import org.apache.s2graph.core.storage.{Storage, StorageManagement, StorageSerDe}
+import org.apache.s2graph.core.utils.logger
+import scalikejdbc._
+
+object JdbcStorage {
+
+  case class Row(row: Map[String, Any])
+
+  object Row {
+    def apply(rs: WrappedResultSet): Row = Row(rs.toMap)
+  }
+
+  val PoolName = "_META_JDBC_STORAGE_"
+  val TablePrefix = "_EDGE_STORE"
+
+  def toMySqlType(tpe: String): String = tpe match {
+    case "int" | "integer" | "i" | "int32" | "integer32" => "int(32)"
+    case "string" | "str" | "s" => "varchar(256)"
+    case "boolean" | "bool" => "tinyint(1)"
+    case "long" | "l" | "int64" | "integer64" => "int(64)"
+    case "float64" | "float" | "f" | "float32" => "float"
+    case "double" | "d" => "double"
+    case _ => ""
+  }
+
+  def buildIndex(label: Label, indices: List[LabelIndex]): String = {
+    if (indices.isEmpty) s"KEY `${label.label}_PK` (`_timestamp`)" + ","
+    else {
+      val nameWithFields = indices.map { index =>
+        val name = index.name
+        val fields = index.propNames
+
+        name -> fields.toList.map(n => s"`${n}`")
+      }
+
+      val ret = nameWithFields.map { case (name, fields) =>
+        s"KEY `${label.label}_${name}` (${fields.mkString(", ")})"
+      }
+
+      ret.mkString(",\n") + ","
+    }
+  }
+
+  def buildProps(metas: List[LabelMeta]): String = {
+    if (metas.isEmpty) ""
+    else {
+      val ret = metas.map { meta =>
+        s"""`${meta.name}` ${toMySqlType(meta.dataType)}""".trim
+      }
+
+      (ret.mkString(",\n  ") + ",").trim
+    }
+  }
+
+  def showSchema(label: Label): String = {
+    val srcColumn = label.srcColumn
+    val tgtColumn = label.srcColumn
+    val metas = LabelMeta.findAllByLabelId(label.id.get, useCache = false).sortBy(_.name)
+    val consistency = label.consistencyLevel
+    val indices = label.indices
+    val isUnique = if (consistency == "strong") "UNIQUE" else ""
+
+    s"""
+       |CREATE TABLE `${labelTableName(label)}`(
+       |  `id` int(11) NOT NULL AUTO_INCREMENT,
+       |  `_timestamp` TIMESTAMP NOT NULL default CURRENT_TIMESTAMP,
+       |  `_from` ${toMySqlType(srcColumn.columnType)} NOT NULL,
+       |  `_to` ${toMySqlType(tgtColumn.columnType)} NOT NULL,
+       |  PRIMARY KEY (`id`),
+       |  ${buildProps(metas)}
+       |  ${buildIndex(label, indices)}
+       |  ${isUnique} KEY `${label.label}_from` (`_from`,`_to`),
+       |  ${isUnique} KEY `${label.label}_to` (`_to`,`_from`)
+       |) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  """.trim.stripMargin
+  }
+
+  def labelTableName(label: Label): String = s"${TablePrefix}_${label.label}"
+
+  def affectedColumns(label: Label): Seq[String] = {
+    Seq("_timestamp", "_from", "_to") ++ LabelMeta.findAllByLabelId(label.id.get, useCache = false).sortBy(_.name).map(_.name)
+  }
+
+  def withTxSession[T](f: => DBSession => T): T = {
+    using(DB(ConnectionPool.borrow(PoolName))) { db =>
+      db localTx { implicit session =>
+        f(session)
+      }
+    }
+  }
+
+  def withReadOnlySession[T](f: => DBSession => T): T = {
+    using(DB(ConnectionPool.borrow(PoolName))) { db =>
+      f(db.readOnlySession())
+    }
+  }
+
+  def dropTable(label: Label): Unit = {
+    val cmd = s"DROP TABLE IF EXISTS ${labelTableName(label)}"
+
+    withTxSession { session =>
+      sql"${SQLSyntax.createUnsafely(cmd)}".execute().apply()(session)
+    }
+  }
+
+  def tables = DB(ConnectionPool.borrow(PoolName)).getTableNames().map(_.toLowerCase())
+
+  def createTable(label: Label): Boolean = {
+    val schema = showSchema(label)
+    val tableName = labelTableName(label)
+
+    if (tables.contains(tableName.toLowerCase())) {
+      logger.info(s"Table exists ${tableName}")
+    } else {
+      withTxSession { session =>
+        sql"${SQLSyntax.createUnsafely(schema)}".execute().apply()(session)
+      }
+    }
+
+    true
+  }
+
+  def prepareConnection(config: Config): Unit = {
+    val jdbcDriverName = config.getString("driver")
+    Class.forName(jdbcDriverName)
+
+    if (!ConnectionPool.isInitialized(PoolName)) {
+      val jdbcUrl = config.getString("url")
+      val user = config.getString("user")
+      val password = config.getString("password")
+      val settings = ConnectionPoolSettings(initialSize = 10, maxSize = 10, connectionTimeoutMillis = 30000L, validationQuery = "select 1;")
+
+      ConnectionPool.add(PoolName, jdbcUrl, user, password, settings)
+    }
+  }
+}
+
+class JdbcStorage(graph: S2GraphLike, config: Config) {
+
+  implicit val ec = graph.ec
+
+  JdbcStorage.prepareConnection(config)
+
+  val h2EdgeFetcher = new JdbcEdgeFetcher(graph)
+  h2EdgeFetcher.init(config)
+
+  val h2EdgeMutator = new JdbcEdgeMutator(graph)
+  h2EdgeMutator.init(config)
+
+  val edgeFetcher: EdgeFetcher = h2EdgeFetcher
+  val edgeMutator: EdgeMutator = h2EdgeMutator
+}
+

--- a/s2core/src/main/scala/org/apache/s2graph/core/utils/Importer.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/utils/Importer.scala
@@ -24,8 +24,7 @@ import java.io.File
 import com.typesafe.config.Config
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.s2graph.core.{EdgeFetcher, S2GraphLike}
-import org.apache.s2graph.core.utils.logger
+import org.apache.s2graph.core.{S2GraphLike}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/s2core/src/main/scala/org/apache/s2graph/core/utils/SafeUpdateCache.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/utils/SafeUpdateCache.scala
@@ -124,7 +124,10 @@ class SafeUpdateCache(val config: Config)
   }
 
   def defaultOnEvict(oldValue: AnyRef): Unit = {
-    logger.info(s"[SafeUpdateCache]: ${oldValue.getClass.getName} $oldValue is evicted.")
+    oldValue match {
+      case None =>
+      case _ => logger.info(s"[SafeUpdateCache]: ${oldValue.getClass.getName} $oldValue is evicted.")
+    }
   }
 
   def withCache[T <: AnyRef](key: String,
@@ -162,7 +165,10 @@ class SafeUpdateCache(val config: Config)
 
               onEvict(cachedVal)
 
-              logger.info(s"withCache update success: $cacheKey")
+              cachedVal match {
+                case None =>
+                case _ => logger.info(s"withCache update success: $cacheKey")
+              }
           }
 
           cachedVal

--- a/s2core/src/test/scala/org/apache/s2graph/core/storage/jdbc/JdbcStorageTest.scala
+++ b/s2core/src/test/scala/org/apache/s2graph/core/storage/jdbc/JdbcStorageTest.scala
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.core.fetcher.sql
+
+import org.apache.s2graph.core.Management.JsonModel._
+import org.apache.s2graph.core._
+import org.apache.s2graph.core.fetcher.BaseFetcherTest
+import org.apache.s2graph.core.schema._
+import org.apache.s2graph.core.storage.jdbc._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+class JdbcStorageTest extends BaseFetcherTest {
+  implicit lazy val ec = graph.ec
+
+  val edgeFetcherName = classOf[JdbcEdgeFetcher].getName
+  val edgeMutatorName = classOf[JdbcEdgeMutator].getName
+
+  val options =
+    s"""
+       |{
+       |  "fetcher": {
+       |    "className": "${edgeFetcherName}",
+       |    "url": "jdbc:h2:file:/tmp/s2graph/metastore;MODE=MYSQL",
+       |    "driver": "org.h2.Driver",
+       |    "password": "sa",
+       |    "user": "sa"
+       |  },
+       |  "mutator": {
+       |    "className": "${edgeMutatorName}",
+       |    "url": "jdbc:h2:file:/tmp/s2graph/metastore;MODE=MYSQL",
+       |    "driver": "org.h2.Driver",
+       |    "password": "sa",
+       |    "user": "sa"
+       |  }
+       |}
+       """.stripMargin
+
+  val serviceName = "s2graph"
+  val columnName = "user"
+
+  var service: Service = _
+  var serviceColumn: ServiceColumn = _
+
+  override def beforeAll: Unit = {
+    super.beforeAll
+
+    service = management.createService(serviceName, "localhost", "s2graph_htable", -1, None).get
+    serviceColumn = management.createServiceColumn(serviceName, columnName, "string", Nil)
+  }
+
+  def clearLabel(labelName: String): Unit = {
+    Label.findByName(labelName, useCache = false).foreach { label =>
+      label.labelMetaSet.foreach { lm =>
+        LabelMeta.delete(lm.id.get)
+      }
+      Label.delete(label.id.get)
+    }
+  }
+
+  def createLabel(labelName: String,
+                  consistencyLevel: String,
+                  props: Seq[Prop],
+                  indices: Seq[Index]): Label = {
+
+    clearLabel(labelName)
+
+    val label = management.createLabel(
+      labelName,
+      service.serviceName, serviceColumn.columnName, serviceColumn.columnType,
+      service.serviceName, serviceColumn.columnName, serviceColumn.columnType,
+      service.serviceName,
+      indices,
+      props,
+      isDirected = true, consistencyLevel = consistencyLevel, hTableName = None, hTableTTL = None,
+      schemaVersion = "v3", compressionAlgorithm = "gz", options = Option(options),
+      initFetcherWithOptions = true
+    ).get
+
+    management.updateEdgeFetcher(label, Option(options))
+    label
+  }
+
+  def normalise(s: String): String = s.split("\n").map(_.trim).filterNot(_.isEmpty).mkString("\n")
+
+  test("CreateLabel - label A: {strong, defaultIndex}") {
+    val props = Seq(
+      Prop(name = "score", defaultValue = "0.0", dataType = "double"),
+      Prop(name = "age", defaultValue = "0", dataType = "int")
+    )
+    val indices = Nil
+
+    val label = createLabel("A", "strong", props, indices)
+
+    val expectedColumn = Seq("_timestamp", "_from", "_to", "age", "score")
+    val actualColumn = JdbcStorage.affectedColumns(label)
+
+    actualColumn shouldBe expectedColumn
+
+    val expectedSchema =
+      """
+    CREATE TABLE `_EDGE_STORE_A`(
+      `id` int(11) NOT NULL AUTO_INCREMENT,
+      `_timestamp` TIMESTAMP NOT NULL default CURRENT_TIMESTAMP,
+      `_from` varchar(256) NOT NULL,
+      `_to` varchar(256) NOT NULL,
+      PRIMARY KEY (`id`),
+      `age` int(32),
+      `score` double,
+      KEY `A__PK` (`_timestamp`),
+      UNIQUE KEY `A_from` (`_from`,`_to`),
+      UNIQUE KEY `A_to` (`_to`,`_from`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    """
+
+    val actualSchema = JdbcStorage.showSchema(label)
+    println(actualSchema)
+
+    normalise(actualSchema) shouldBe normalise(expectedSchema)
+  }
+
+  test("CreateLabel - label B: {strong, (age, score) index}") {
+    val props = Seq(
+      Prop(name = "score", defaultValue = "0.0", dataType = "double"),
+      Prop(name = "age", defaultValue = "0", dataType = "int")
+    )
+    val indices = Seq(
+      Index("idx_age_score", Seq("age", "score"))
+    )
+
+    val label = createLabel("B", "strong", props, indices)
+
+    val expectedColumn = Seq("_timestamp", "_from", "_to", "age", "score")
+    val actualColumn = JdbcStorage.affectedColumns(label)
+
+    actualColumn shouldBe expectedColumn
+
+    val expectedSchema =
+      """
+      CREATE TABLE `_EDGE_STORE_B`(
+        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `_timestamp` TIMESTAMP NOT NULL default CURRENT_TIMESTAMP,
+        `_from` varchar(256) NOT NULL,
+        `_to` varchar(256) NOT NULL,
+        PRIMARY KEY (`id`),
+        `age` int(32),
+        `score` double,
+        KEY `B_idx_age_score` (`age`, `score`),
+        UNIQUE KEY `B_from` (`_from`,`_to`),
+        UNIQUE KEY `B_to` (`_to`,`_from`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+      """
+
+    val actualSchema = JdbcStorage.showSchema(label)
+    normalise(actualSchema) shouldBe normalise(expectedSchema)
+  }
+
+  test("CreateLabel - label C: {weak, defaultIndex}") {
+    val props = Seq(
+      Prop(name = "score", defaultValue = "0.0", dataType = "double"),
+      Prop(name = "age", defaultValue = "0", dataType = "int")
+    )
+    val indices = Nil
+
+    val label = createLabel("C", "weak", props, indices)
+
+    val expectedColumn = Seq("_timestamp", "_from", "_to", "age", "score")
+    val actualColumn = JdbcStorage.affectedColumns(label)
+
+    actualColumn shouldBe expectedColumn
+
+    val expectedSchema =
+      """
+      CREATE TABLE `_EDGE_STORE_C`(
+        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `_timestamp` TIMESTAMP NOT NULL default CURRENT_TIMESTAMP,
+        `_from` varchar(256) NOT NULL,
+        `_to` varchar(256) NOT NULL,
+        PRIMARY KEY (`id`),
+        `age` int(32),
+        `score` double,
+        KEY `C__PK` (`_timestamp`),
+        KEY `C_from` (`_from`,`_to`),
+        KEY `C_to` (`_to`,`_from`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+      """
+
+    val actualSchema = JdbcStorage.showSchema(label)
+    normalise(actualSchema) shouldBe normalise(expectedSchema)
+  }
+
+  test("Mutate and fetch edges - label A") {
+    val label = Label.findByName("A", useCache = false).get
+
+    JdbcStorage.dropTable(label)
+    JdbcStorage.createTable(label)
+
+    val fetcher = graph.getEdgeFetcher(label)
+    val mutator = graph.getEdgeMutator(label)
+
+    val edgeElric =
+      graph.toEdge("daewon", "elric", label.label, "out", Map("score" -> 90), ts = 10)
+
+    val edgeRain =
+      graph.toEdge("daewon", "rain", label.label, "out", Map("score" -> 50), ts = 5)
+
+    val edgeShon =
+      graph.toEdge("daewon", "shon", label.label, "out", Map("score" -> 100), ts = 15)
+
+    val edgeElricUpdated =
+      graph.toEdge("daewon", "elric", label.label, "out", Map("score" -> 200), ts = 20)
+
+    val insertEdges = Seq(edgeShon, edgeElric, edgeRain)
+    val updateEdges = Seq(edgeElricUpdated)
+
+    Await.ready(mutator.mutateStrongEdges("", insertEdges, true), Duration("10 sec"))
+    Await.ready(mutator.mutateStrongEdges("", updateEdges, true), Duration("10 sec"))
+
+    val qp = QueryParam(labelName = label.label, offset = 0, limit = 10)
+    val vertex = edgeElric.srcVertex
+    val step = Step(Seq(qp))
+    val q = Query(Seq(vertex), steps = Vector(step))
+    val qr = QueryRequest(q, 0, vertex, qp)
+
+    val fetchedEdges = Await.result(
+      fetcher.fetches(Seq(qr), Map.empty), Duration("10 sec")).flatMap(_.edgeWithScores.map(_.edge)
+    )
+
+    fetchedEdges shouldBe Seq(edgeElricUpdated, edgeShon, edgeRain) // order by timestamp desc
+  }
+
+  test("Mutate and fetch edges - label C") {
+    val label = Label.findByName("C", useCache = false).get
+
+    JdbcStorage.dropTable(label)
+    JdbcStorage.createTable(label)
+
+    val fetcher = graph.getEdgeFetcher(label)
+    val mutator = graph.getEdgeMutator(label)
+
+    val edgeShon =
+      graph.toEdge("daewon", "shon", label.label, "out", Map("score" -> 90), ts = 10)
+
+    val edgeShon2 =
+      graph.toEdge("daewon", "shon", label.label, "out", Map("score" -> 50), ts = 5)
+
+    val insertEdges = Seq(edgeShon, edgeShon2)
+
+    Await.ready(mutator.mutateStrongEdges("", insertEdges, true), Duration("10 sec"))
+
+    val qp = QueryParam(labelName = label.label, offset = 0, limit = 10, duplicatePolicy = DuplicatePolicy.Raw)
+    val vertex = edgeShon.srcVertex
+    val step = Step(Seq(qp))
+    val q = Query(Seq(vertex), steps = Vector(step))
+    val qr = QueryRequest(q, 0, vertex, qp)
+
+    val fetchedEdges = Await.result(
+      fetcher.fetches(Seq(qr), Map.empty), Duration("10 sec")).flatMap(_.edgeWithScores.map(_.edge)
+    )
+
+    fetchedEdges shouldBe Seq(edgeShon, edgeShon2)
+  }
+}

--- a/s2graphql/src/test/scala/org/apache/s2graph/graphql/TestGraph.scala
+++ b/s2graphql/src/test/scala/org/apache/s2graph/graphql/TestGraph.scala
@@ -77,7 +77,7 @@ trait TestGraph {
 }
 
 class EmptyGraph(config: Config) extends TestGraph {
-  Schema.apply(config)
+  org.apache.s2graph.core.schema.Schema.apply(config)
 
   lazy val graph = new S2Graph(config)(scala.concurrent.ExecutionContext.Implicits.global)
   lazy val management = new Management(graph)
@@ -92,7 +92,7 @@ class EmptyGraph(config: Config) extends TestGraph {
   override def repository: GraphRepository = s2Repository
 
   override def open(): Unit = {
-    Schema.shutdown(true)
+    org.apache.s2graph.core.schema.Schema.shutdown(true)
   }
 
 }
@@ -131,9 +131,10 @@ class BasicGraph(config: Config) extends EmptyGraph(config) {
       labelName,
       serviceName, columnName, "string",
       serviceName, columnName, "string",
-      true, serviceName,
+      serviceName,
       Nil,
       Seq(Prop("score", "0", "int")),
+      true,
       "strong"
     )
 }


### PR DESCRIPTION
# Implement EdgeMutator and EdgeFetcher for JDBC interface.

I chose the H2 DB(org.h2.Drvier) as the JDBC Driver implementation.
The current implementation is to work for each Label according to the Label option.

I plan to move to the storage level later.

## Lable option example

```json
{
  "fetcher": {
    "className": "org.apache.s2graph.core.storage.jdbc.JdbcEdgeFetcher",
    "url": "jdbc:h2:file:/tmp/s2graph/metastore;MODE=MYSQL",
    "driver": "org.h2.Driver",
    "password": "sa",
    "user": "sa"
  },
  "mutator": {
    "className": "org.apache.s2graph.core.storage.jdbc.JdbcEdgeMutator",
    "url": "jdbc:h2:file:/tmp/s2graph/metastore;MODE=MYSQL",
    "driver": "org.h2.Driver",
    "password": "sa",
    "user": "sa"
  }
}
```

## Implemented functionality.
  - Basic Edge CRUD with Strong, Weak consistency option.  

## TODO: 
  - Implement VertexMutator, VertexFetcher
  - Other JDBC support, including PostgreSQL 

