### PR TITLE
[S2GRAPH-216] Provide a transform directive in the GraphQL query result

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,9 @@ name := "s2graph"
 
 lazy val commonSettings = Seq(
   organization := "org.apache.s2graph",
-  scalaVersion := "2.11.7",
+  scalaVersion := "2.11.8",
   isSnapshot := version.value.endsWith("-SNAPSHOT"),
-  scalacOptions := Seq("-language:postfixOps", "-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlint:-missing-interpolator"),
+  scalacOptions := Seq("-language:postfixOps", "-unchecked", "-deprecation", "-feature", "-Xlint", "-Xlint:-missing-interpolator", "-target:jvm-1.8"),
   javaOptions ++= collection.JavaConversions.propertiesAsScalaMap(System.getProperties).map { case (key, value) => "-D" + key + "=" + value }.toSeq,
   testOptions in Test += Tests.Argument("-oDF"),
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),

--- a/s2core/build.sbt
+++ b/s2core/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
   "org.apache.tinkerpop" % "gremlin-test" % tinkerpopVersion % "test",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.specs2" %% "specs2-core" % specs2Version % "test",
-  "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion ,
+  "org.apache.hadoop" % "hadoop-hdfs" % hadoopVersion,
   "org.apache.lucene" % "lucene-core" % "6.6.0",
   "org.apache.lucene" % "lucene-queryparser" % "6.6.0",
   "org.rocksdb" % "rocksdbjni" % rocksVersion,

--- a/s2graphql/build.sbt
+++ b/s2graphql/build.sbt
@@ -26,13 +26,15 @@ description := "GraphQL server with akka-http and sangria and s2graph"
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+
   "org.sangria-graphql" %% "sangria" % "1.4.0",
   "org.sangria-graphql" %% "sangria-spray-json" % "1.0.0",
   "org.sangria-graphql" %% "sangria-play-json" % "1.0.1" % Test,
 
   "com.typesafe.akka" %% "akka-http" % "10.0.10",
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.10",
-
   "com.typesafe.akka" %% "akka-slf4j" % "2.4.6",
 
   "org.scalatest" %% "scalatest" % "3.0.4" % Test

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/GraphQLServer.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/GraphQLServer.scala
@@ -115,6 +115,8 @@ object GraphQLServer {
     newSchema
   }
 
+  val transformMiddleWare = new org.apache.s2graph.graphql.middleware.Transform()
+
   private def executeGraphQLQuery(query: Document, op: Option[String], vars: JsObject)(implicit e: ExecutionContext) = {
     val cacheKey = className + "s2Schema"
     val s2schema = schemaCache.withCache(cacheKey, broadcast = false)(createNewSchema())
@@ -127,7 +129,8 @@ object GraphQLServer {
       s2Repository,
       variables = vars,
       operationName = op,
-      deferredResolver = resolver
+      deferredResolver = resolver,
+      middleware = List(transformMiddleWare)
     )
       .map((res: spray.json.JsValue) => OK -> res)
       .recover {

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/middleware/Transform.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/middleware/Transform.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.graphql.middleware
+
+import org.apache.s2graph.graphql.types.S2Directive
+import sangria.ast.StringValue
+import sangria.execution.{Middleware, MiddlewareAfterField, MiddlewareQueryContext}
+import sangria.schema.Context
+
+case class Transform() extends Middleware[Any] with MiddlewareAfterField[Any] {
+  type QueryVal = Unit
+  type FieldVal = Unit
+
+  def beforeQuery(context: MiddlewareQueryContext[Any, _, _]) = ()
+
+  def afterQuery(queryVal: QueryVal, context: MiddlewareQueryContext[Any, _, _]) = ()
+
+  def beforeField(cache: QueryVal, mctx: MiddlewareQueryContext[Any, _, _], ctx: Context[Any, _]) = continue
+
+  def afterField(cache: QueryVal, fromCache: FieldVal, value: Any, mctx: MiddlewareQueryContext[Any, _, _], ctx: Context[Any, _]) = {
+
+    value match {
+      case s: String => {
+        val transformFuncOpt = ctx.astFields.headOption.flatMap(_.directives.find(_.name == S2Directive.Transform.name)).map { directive =>
+          directive.arguments.head.value.asInstanceOf[StringValue].value
+        }
+
+        transformFuncOpt.map(funcString => S2Directive.resolveTransform(funcString, s)).orElse(Option(s))
+      }
+
+      case _ ⇒ None
+    }
+  }
+}

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/FieldResolver.scala
@@ -28,7 +28,6 @@ import org.apache.s2graph.graphql.types.S2Type.EdgeQueryParam
 import sangria.schema._
 
 object FieldResolver {
-
   def graphElement[A](name: String, cType: String, c: Context[GraphRepository, Any]): A = {
     c.value match {
       case v: S2VertexLike => name match {
@@ -36,6 +35,7 @@ object FieldResolver {
         case _ =>
           val innerVal = v.propertyValue(name).get
           JSONParser.innerValToAny(innerVal, cType).asInstanceOf[A]
+
       }
       case e: S2EdgeLike => name match {
         case "timestamp" => e.ts.asInstanceOf[A]

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2Directive.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/S2Directive.scala
@@ -1,0 +1,49 @@
+package org.apache.s2graph.graphql.types
+
+import sangria.schema.{Argument, Directive, DirectiveLocation, StringType}
+
+object S2Directive {
+
+  object Eval {
+
+    import scala.collection._
+
+    val codeMap = mutable.Map.empty[String, () => Any]
+
+    def compileCode(code: String): () => Any = {
+      import scala.tools.reflect.ToolBox
+      val toolbox = reflect.runtime.currentMirror.mkToolBox()
+
+      toolbox.compile(toolbox.parse(code))
+    }
+
+    def getCompiledCode[T](code: String): T = {
+      val compiledCode = Eval.codeMap.getOrElseUpdate(code, Eval.compileCode(code))
+
+      compiledCode
+        .asInstanceOf[() => Any]
+        .apply()
+        .asInstanceOf[T]
+    }
+  }
+
+  type TransformFunc = String => String
+
+  val funcArg = Argument("func", StringType)
+
+  val Transform =
+    Directive("transform",
+      arguments = List(funcArg),
+      locations = Set(DirectiveLocation.Field),
+      shouldInclude = _ => true)
+
+  def resolveTransform(code: String, input: String): String = {
+    try {
+      val fn = Eval.getCompiledCode[TransformFunc](code)
+
+      fn.apply(input)
+    } catch {
+      case e: Exception => e.toString
+    }
+  }
+}

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
@@ -20,8 +20,6 @@
 package org.apache.s2graph.graphql.types
 
 import org.apache.s2graph.graphql.repository.GraphRepository
-import org.apache.s2graph.graphql.types._
-
 
 /**
   * S2Graph GraphQL schema.
@@ -47,5 +45,13 @@ class SchemaDef(g: GraphRepository) {
     fields(s2Type.mutationFields ++ mutateManagementFields: _*)
   )
 
-  val S2GraphSchema = Schema(S2QueryType, Option(S2MutationType))
+  val directives = S2Directive.Transform :: BuiltinDirectives
+
+  private val s2Schema = Schema(
+    S2QueryType,
+    Option(S2MutationType),
+    directives = directives
+  )
+
+  val S2GraphSchema = s2Schema
 }

--- a/s2graphql/src/test/scala/org/apache/s2graph/graphql/DirectiveTest.scala
+++ b/s2graphql/src/test/scala/org/apache/s2graph/graphql/DirectiveTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.s2graph.graphql
+
+import com.typesafe.config.ConfigFactory
+import org.apache.s2graph.graphql.types.S2Directive
+import org.scalatest._
+
+class DirectiveTest extends FunSuite with Matchers with BeforeAndAfterAll {
+  var testGraph: TestGraph = _
+
+  override def beforeAll = {
+    val config = ConfigFactory.load()
+    testGraph = new EmptyGraph(config)
+    testGraph.open()
+  }
+
+  override def afterAll(): Unit = {
+    testGraph.cleanup()
+  }
+
+  test("transform") {
+    val input = "20170601_A0"
+    val code =
+      """ (s: String) => {
+          val date = s.split("_").head
+          s"http://abc.xy.com/IMG_${date}.png"
+      }
+
+      """.stripMargin
+    val actual = S2Directive.resolveTransform(code, input)
+    val expected = "http://abc.xy.com/IMG_20170601.png"
+
+    actual shouldBe expected
+  }
+}


### PR DESCRIPTION
# Provide a transform directive in the GraphQL query result

I Implemented the string manipulation using the `scala.tools`.  

The code(scala) to be created must be a function that takes a 'String' as an argument and returns a 'String'.


 Here is a query that appends `prefix_` to the `label` column.

```sql
select concat ('prefix_', label) as with_prefix from labels limit 2
```

Here is an example of writing a function that supports the above functions in SQL.
```graphql
{
   labels {
     label @transform (func: "(s: String) => \" prefix \ _ "+ s") # scala anonymous function
   }
}
```