### PR TITLE
[S2GRAPH-218] add operations not supported on sql

### DIFF
--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
@@ -69,6 +69,8 @@ abstract class Sink(queryName: String, override val conf: TaskConf) extends Task
     }
     val interval = conf.options.getOrElse("interval", DEFAULT_TRIGGER_INTERVAL)
     val checkpointLocation = conf.options.getOrElse("checkpointLocation", DEFAULT_CHECKPOINT_LOCATION)
+    val isContinuous = conf.options.getOrElse("isContinuous", "false").toBoolean
+    val trigger = if (isContinuous) Trigger.Continuous(interval) else Trigger.ProcessingTime(interval)
 
     val cfg = conf.options ++ Map("checkpointLocation" -> checkpointLocation)
 
@@ -78,7 +80,7 @@ abstract class Sink(queryName: String, override val conf: TaskConf) extends Task
       .queryName(s"${queryName}_${conf.name}")
       .format(FORMAT)
       .options(cfg)
-      .trigger(Trigger.ProcessingTime(interval))
+      .trigger(trigger)
       .outputMode(mode)
       .start()
   }

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
@@ -93,7 +93,7 @@ abstract class Sink(queryName: String, override val conf: TaskConf) extends Task
       case _ => SaveMode.Overwrite
     }
 
-    val partitionedWriter = if (partitionsOpt.isDefined) writer.partitionBy(partitionsOpt.get) else writer
+    val partitionedWriter = if (partitionsOpt.isDefined) writer.partitionBy(partitionsOpt.get.split(","): _*) else writer
 
     writeBatchInner(partitionedWriter.format(FORMAT).mode(mode))
   }

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Task.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Task.scala
@@ -42,8 +42,7 @@ object TaskConf {
     taskConf.options.filterKeys(_.startsWith("cache.")).mapValues(_.toInt)
   }
 }
-
-case class TaskConf(name: String, `type`: String, inputs: Seq[String] = Nil, options: Map[String, String] = Map.empty)
+case class TaskConf(name:String, `type`:String, inputs:Seq[String] = Nil, options:Map[String, String] = Map.empty, cache:Option[Boolean]=None)
 
 trait Task extends Serializable with Logger {
   val conf: TaskConf


### PR DESCRIPTION
I have added some operations that are not represented in spark SQL.
* Windowed Grouped Aggregations : grouped.*
* Watermark : watermark.delay.time, time.column
* Streaming Deduplication : drop.duplicate.columns
* dataframe cache option : cache
* Continuous Streaming : isContinuous

#### ex) job_description (process)
```
{
    "name": "category_distinct",
    "inputs": [
          "category_bulk"
    ],
    "type": "sql",
    "options": {
        "sql": "SELECT url, category FROM category_bulk",
        "drop.duplicate.columns": "url,category"     // deduplicate
    }
    "cache": "true"   // cache (only support not streaming dataframe)
},
{
    "name": "grouped",
    "inputs": [
        "demo_join"
    ],
    "type": "sql",
    "options": {
        "sql": "SELECT * FROM demo_join",
        "watermark.delay.time": "1 minutes",                      // watermark
        "time.column": "ts",
        "grouped.keys": "age_band, gender, category",    // windowed grouped aggregation
        "grouped.window.duration": "5 minutes",
        "grouped.slide.duration": "5 minutes",
        "grouped.dataset.agg": "[\"count(1) as cnt\"]"
    }
}
```