### PR TITLE
[S2GRAPH-230]: ResourceManager onEvict cause segmentation fault with AnnoyModelFetcher

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/utils/SafeUpdateCache.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/utils/SafeUpdateCache.scala
@@ -161,8 +161,8 @@ class SafeUpdateCache(val config: Config)
               put(key, cachedVal, false)
               logger.error(s"withCache update failed: $cacheKey", ex)
             case Success(newValue) =>
-              put(key, newValue, broadcast = (broadcast && newValue != cachedVal))
 
+              put(key, newValue, broadcast = (broadcast && newValue != cachedVal))
               onEvict(cachedVal)
 
               cachedVal match {


### PR DESCRIPTION
- add background task on ResourceManager onEvict.