### PR TITLE
[S2GRAPH-232] Elimination of inefficiency due to duplication in GraphQL schema generation.

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/schema/ColumnMeta.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/schema/ColumnMeta.scala
@@ -136,6 +136,8 @@ object ColumnMeta extends SQLSyntaxSupport[ColumnMeta] {
       val cacheKey = className + s"columnId=${columnId}"
       (cacheKey -> ls)
     }.toList)
+
+    ls
   }
 
   def updateStoreInGlobalIndex(id: Int, storeInGlobalIndex: Boolean)(implicit session: DBSession = AutoSession): Try[Long] = Try {

--- a/s2core/src/main/scala/org/apache/s2graph/core/schema/LabelIndex.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/schema/LabelIndex.scala
@@ -166,6 +166,8 @@ object LabelIndex extends SQLSyntaxSupport[LabelIndex] {
       val cacheKey = s"labelId=${labelId}"
       (className + cacheKey -> ls)
     }.toList)
+
+    ls
   }
 }
 

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/GraphQLServer.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/GraphQLServer.scala
@@ -58,7 +58,7 @@ class GraphQLServer() {
   val config = ConfigFactory.load()
   val s2graph = new S2Graph(config)
   val schemaCacheTTL = Try(config.getInt("schemaCacheTTL")).getOrElse(3000)
-  val withAdmin = Try(config.getBoolean("schemaCacheTTL")).getOrElse(false)
+  val enableMutation = Try(config.getBoolean("enableMutation")).getOrElse(false)
 
   val schemaConfig = ConfigFactory.parseMap(Map(
     SafeUpdateCache.MaxSizeKey -> 1, SafeUpdateCache.TtlKey -> schemaCacheTTL
@@ -81,7 +81,7 @@ class GraphQLServer() {
 
   val schemaCacheKey = className + "s2Schema"
 
-  schemaCache.put(schemaCacheKey, createNewSchema(withAdmin))
+  schemaCache.put(schemaCacheKey, createNewSchema(enableMutation))
 
   /**
     * In development mode(schemaCacheTTL = 1),
@@ -127,7 +127,7 @@ class GraphQLServer() {
     import GraphRepository._
 
     val (schemaDef, s2Repository) =
-      schemaCache.withCache(schemaCacheKey, broadcast = false, onEvict = onEvictSchema)(createNewSchema(withAdmin))
+      schemaCache.withCache(schemaCacheKey, broadcast = false, onEvict = onEvictSchema)(createNewSchema(enableMutation))
 
     val resolver: DeferredResolver[GraphRepository] = DeferredResolver.fetchers(vertexFetcher, edgeFetcher)
 

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
@@ -273,14 +273,29 @@ class GraphRepository(val graph: S2GraphLike) {
 
   def deleteLabel(args: Args): Try[Label] = {
     val labelName = args.arg[String]("name")
-
     val deleteLabelTry = Management.deleteLabel(labelName)
+
     withLogTryResponse("deleteLabel", deleteLabelTry)
   }
 
-  def services(): List[Service] = Service.findAll()
+  def services(): List[Service] = {
+    Service.findAll()
+  }
 
-  def serviceColumns(): List[ServiceColumn] = ServiceColumn.findAll()
+  def serviceColumns(): List[ServiceColumn] = {
+    val allServices = services().toSet
 
-  def labels() = Label.findAll()
+    ServiceColumn
+      .findAll()
+      .filter(sc => allServices(sc.service))
+  }
+
+  def labels() = {
+    val allServiceColumns = serviceColumns().toSet
+
+    Label
+      .findAll()
+      .filter(l => allServiceColumns(l.srcColumn) || allServiceColumns(l.tgtColumn))
+  }
+
 }

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/repository/GraphRepository.scala
@@ -279,7 +279,7 @@ class GraphRepository(val graph: S2GraphLike) {
   }
 
   def services(): List[Service] = {
-    Service.findAll()
+    Service.findAll().distinct
   }
 
   def serviceColumns(): List[ServiceColumn] = {
@@ -288,6 +288,7 @@ class GraphRepository(val graph: S2GraphLike) {
     ServiceColumn
       .findAll()
       .filter(sc => allServices(sc.service))
+      .distinct
   }
 
   def labels() = {
@@ -296,6 +297,6 @@ class GraphRepository(val graph: S2GraphLike) {
     Label
       .findAll()
       .filter(l => allServiceColumns(l.srcColumn) || allServiceColumns(l.tgtColumn))
+      .distinct
   }
-
 }

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
@@ -26,7 +26,7 @@ import org.apache.s2graph.graphql.repository.GraphRepository
   *
   * When a Label or Service is created, the GraphQL schema is created dynamically.
   */
-class SchemaDef(g: GraphRepository) {
+class SchemaDef(g: GraphRepository, withAdmin: Boolean = false) {
 
   import sangria.schema._
 
@@ -39,17 +39,24 @@ class SchemaDef(g: GraphRepository) {
     fields(s2Type.queryFields ++ queryManagementFields: _*)
   )
 
-  val mutateManagementFields = List(wrapField("MutationManagement", "Management", s2ManagementType.mutationFields))
-  val S2MutationType = ObjectType[GraphRepository, Any](
-    "Mutation",
-    fields(s2Type.mutationFields ++ mutateManagementFields: _*)
-  )
+  lazy val mutateManagementFields = List(wrapField("MutationManagement", "Management", s2ManagementType.mutationFields))
+
+  val S2MutationType =
+    if (!withAdmin) None
+    else {
+      val mutationTpe = ObjectType[GraphRepository, Any](
+        "Mutation",
+        fields(s2Type.mutationFields ++ mutateManagementFields: _*)
+      )
+
+      Option(mutationTpe)
+    }
 
   val directives = S2Directive.Transform :: BuiltinDirectives
 
   private val s2Schema = Schema(
     S2QueryType,
-    Option(S2MutationType),
+    S2MutationType,
     directives = directives
   )
 

--- a/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
+++ b/s2graphql/src/main/scala/org/apache/s2graph/graphql/types/SchemaDef.scala
@@ -20,6 +20,9 @@
 package org.apache.s2graph.graphql.types
 
 import org.apache.s2graph.graphql.repository.GraphRepository
+import sangria.schema.ObjectType
+
+import scala.collection.mutable
 
 /**
   * S2Graph GraphQL schema.
@@ -60,5 +63,5 @@ class SchemaDef(g: GraphRepository, withAdmin: Boolean = false) {
     directives = directives
   )
 
-  val S2GraphSchema = s2Schema
+  val schema = s2Schema
 }


### PR DESCRIPTION
When I created an issue, I expected that there would be a load on duplicate ObjectType generation.

However, the profiling result was actually a lot of DB round trips in the bottleneck area.

For example, to create an ObjectType for a Label, the LabelMeta and LabelIndex value included in the label must be brought up.

Since all the data needed to generate the schema is needed only once, the entire data is read in advance and the data is generated.

Since the DB data is all metadata, the size is small, so it does not burden the memory.

It can also help manage the cache's validity cycle by reading the data all at once.