### PR TITLE
 "select":["props"] doesn't work of getEdges

### DIFF
--- a/s2core/src/main/scala/org/apache/s2graph/core/PostProcess.scala
+++ b/s2core/src/main/scala/org/apache/s2graph/core/PostProcess.scala
@@ -458,8 +458,12 @@ object PostProcess extends JSONParser {
     } yield {
       val targetColumns = if (q.selectColumnsSet.isEmpty) reservedColumns else (reservedColumns & q.selectColumnsSet) + "props"
       val _propsMap = queryParam.label.metaPropsDefaultMapInner ++ propsToJson(edge, q, queryParam)
-      val propsMap = if (q.selectColumnsSet.nonEmpty) _propsMap.filterKeys(q.selectColumnsSet) else _propsMap
+      var propsMap = if (q.selectColumnsSet.nonEmpty) _propsMap.filterKeys(q.selectColumnsSet) else _propsMap
 
+      if (propsMap.isEmpty && q.selectColumnsSet.contains("props")) {
+        propsMap = _propsMap
+      }
+      
       val kvMap = targetColumns.foldLeft(Map.empty[String, JsValue]) { (map, column) =>
         val jsValue = column match {
           case "cacheRemain" => JsNumber(queryParam.cacheTTLInMillis - (System.currentTimeMillis() - queryParam.timestamp))


### PR DESCRIPTION
The "select" field can decide what should be includ in the query result of getEdges.	
In my application , I used getEdges , and I want get the total "props" result in the query result;
so I set "select":["props"] in the getEdges’s command  according to "Query Level Options",but it did not get the right result.
actually，the "select" field can affect the child filed of “props”，but can not  affect the total "props" field.