### PR TITLE
[S2GRAPH-251] add jdbc options 

### DIFF
--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobDescription.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/JobDescription.scala
@@ -54,6 +54,7 @@ object JobDescription extends Logger {
       case "kafka" => new KafkaSource(conf)
       case "file"  => new FileSource(conf)
       case "hive" => new HiveSource(conf)
+      case "jdbc" => new JdbcSource(conf)
       case "s2graph" => new S2GraphSource(conf)
       case _ => throw new IllegalArgumentException(s"unsupported source type : ${conf.`type`}")
     }
@@ -86,6 +87,7 @@ object JobDescription extends Logger {
       case "file" => new FileSink(jobName, conf)
       case "es" => new ESSink(jobName, conf)
       case "s2graph" => new S2GraphSink(jobName, conf)
+      case "jdbc" => new JdbcSink(jobName, conf)
       case "custom" =>
         val customClassOpt = conf.options.get("class")
         customClassOpt match {

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Sink.scala
@@ -180,6 +180,20 @@ class HiveSink(queryName: String, conf: TaskConf) extends Sink(queryName, conf) 
 }
 
 /**
+  * JdbcSink
+  * @param queryName
+  * @param conf
+  */
+class JdbcSink(queryName: String, conf: TaskConf) extends Sink(queryName, conf) {
+  override def mandatoryOptions: Set[String] = Set("url", "dbtable")
+  override val FORMAT: String = "jdbc"
+
+  override protected def writeBatchInner(writer: DataFrameWriter[Row]): Unit = {
+    writer.format("jdbc").options(conf.options).save()
+  }
+}
+
+/**
   * ESSink
   *
   * @param queryName

--- a/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Source.scala
+++ b/s2jobs/src/main/scala/org/apache/s2graph/s2jobs/task/Source.scala
@@ -131,6 +131,14 @@ class HiveSource(conf:TaskConf) extends Source(conf) {
   }
 }
 
+class JdbcSource(conf:TaskConf) extends Source(conf) {
+  override def mandatoryOptions: Set[String] = Set("url", "dbtable")
+  override def toDF(ss: SparkSession): DataFrame = {
+    ss.read.format("jdbc").options(conf.options).load()
+  }
+
+}
+
 class S2GraphSource(conf: TaskConf) extends Source(conf) {
   import org.apache.s2graph.spark.sql.streaming.S2SourceConfigs._
   override def mandatoryOptions: Set[String] = Set(


### PR DESCRIPTION
I simply added 'jdbc' options. 

You can create Spark DataFrame from jdbc storage like below example,
```
"source": [
    {
          "name": "jdbc_storage",
          "inputs": [],
          "type": "jdbc",
          "options": {
            "driver": "com.mysql.jdbc.Driver",
            "url": "jdbc:mysql://localhost:3306/mydb",
            "dbtable": "mytable",
            "user": "user",
            "password": "password",
            "fetchsize": "10"
          }
    }
]
```

and write from dataframe to jdbc storage.
```
"sink": [
    {
          "name": "jdbc_sink",
          "inputs": [
            "my_dataframe"
          ]
          "type": "jdbc",
          "options": {
            "driver": "com.mysql.jdbc.Driver",
            "url": "jdbc:mysql://localhost:3306/mydb",
            "dbtable": "mytable",
            "user": "user",
            "password": "password",
            "batchsize": "10",
            "mode": "append"
          }
    }
]
```

Please check the URL below for a list of available options
https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html