### PR TITLE
Use variables for curl example base url with localhost:8000 as default

### DIFF
--- a/doc/source/api/management/index.rst
+++ b/doc/source/api/management/index.rst
@@ -36,9 +36,9 @@ Basic Service Operations
 
 You can create a service using the following API:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/admin/createService -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/admin/createService -H 'Content-Type: Application/json' -d '
   {
      "serviceName": "s2graph",
      "cluster": "address for zookeeper",
@@ -133,9 +133,9 @@ Basic Label Operations
 Here is an sample request that creates a label ``user_article_liked`` between column ``user_id`` of service ``s2graph`` and column ``article_id`` of service ``s2graph_news``.
 Note that the default indexed property ``_timestamp`` will be created since the ``indexedProps`` field is empty.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/admin/createLabel -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/createLabel -H 'Content-Type: Application/json' -d '
    {
      "label": "user_article_liked",
      "srcServiceName": "s2graph",
@@ -156,9 +156,9 @@ This time, edges are managed by both affinity_score and ``_timestamp``.
 
 Friends with higher affinity_scores come first and if affinity_score is a tie, recently added friends comes first.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/admin/createLabel -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/createLabel -H 'Content-Type: Application/json' -d '
    {
      "label": "friends",
      "srcServiceName": "s2graph",
@@ -184,9 +184,9 @@ Friends with higher affinity_scores come first and if affinity_score is a tie, r
 S2Graph supports **multiple indices** on a label which means you can add separate ordering options for edges.
 
 
-.. code:: bash
+.. parsed-literal::
 
-    curl -XPOST localhost:9000/admin/addIndex -H 'Content-Type: Application/json' -d '
+    curl -XPOST |example_base_url|/admin/addIndex -H 'Content-Type: Application/json' -d '
     {
       "label": "friends",
       "indices": [
@@ -196,16 +196,16 @@ S2Graph supports **multiple indices** on a label which means you can add separat
 
 In order to get general information on a label, make a GET request to ``/admin/getLabel/{label name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XGET localhost:9000/admin/getLabel/friends
+   curl -XGET |example_base_url|/admin/getLabel/friends
 
 
 Delete a label with a PUT request to ``/admin/deleteLabel/{label name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPUT localhost:9000/admin/deleteLabel/friends
+   curl -XPUT |example_base_url|/admin/deleteLabel/friends
 
 
 Label updates are not supported (except when you are adding an index). Instead, you can delete the label and re-create it.
@@ -215,9 +215,9 @@ Adding Extra Properties to Labels
 
 To add a new property, use ``/admin/addProp/{label name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/admin/addProp/friend -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/addProp/friend -H 'Content-Type: Application/json' -d '
    {
      "name": "is_blocked",
      "defaultValue": false,
@@ -343,14 +343,14 @@ Using a vertex-centric index, having millions of edges is fine as long as size K
 New indexes can be dynamically added, but will not be applied to pre-existing data (support for this is planned for future versions). Currently, a label can have up to eight indices.
 The following is an example of adding index ``play_count`` to a label ``graph_test``.
 
-.. code:: bash
+.. parsed-literal::
 
    # add prop first
-   curl -XPOST localhost:9000/admin/addProp/graph_test -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/addProp/graph_test -H 'Content-Type: Application/json' -d '
    { "name": "play_count", "defaultValue": 0, "dataType": "integer" }'
 
    # then add index
-   curl -XPOST localhost:9000/admin/addIndex -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/addIndex -H 'Content-Type: Application/json' -d '
    {
      "label": "graph_test",
       "indices": [
@@ -392,9 +392,9 @@ Basic Service Column Operations
 Here are some sample requests for Service Column creation as well as vertex insertion and selection.
 
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/admin/createServiceColumn -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/createServiceColumn -H 'Content-Type: Application/json' -d '
    {
      "serviceName": "s2graph",
      "columnName": "user_id",
@@ -410,25 +410,25 @@ Here are some sample requests for Service Column creation as well as vertex inse
 
 General information on a vertex schema can be retrieved with ``/admin/getServiceColumn/{service name}/{column name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XGET localhost:9000/admin/getServiceColumn/s2graph/user_id
+   curl -XGET |example_base_url|/admin/getServiceColumn/s2graph/user_id
 
 This will give all properties on serviceName ``s2graph`` and columnName ``user_id`` serviceColumn.
 Properties can be added to a Service Column with ``/admin/addServiceColumnProps/{service name}/{column name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/admin/addServiceColumnProps/s2graph/user_id -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/admin/addServiceColumnProps/s2graph/user_id -H 'Content-Type: Application/json' -d '
    [
      {"name": "home_address", "defaultValue": "korea", "dataType": "string"}
    ]'
 
 Vertices can be inserted to a Service Column using ``/admin/vertices/insert/{service name}/{column name}``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/vertex/insert/s2graph/user_id -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/vertex/insert/s2graph/user_id -H 'Content-Type: Application/json' -d '
    [
      {"id":1,"props":{"is_active":true}, "timestamp":1417616431},
      {"id":2,"props":{},"timestamp":1417616431}
@@ -436,9 +436,9 @@ Vertices can be inserted to a Service Column using ``/admin/vertices/insert/{ser
 
 Finally, query your vertex via ``/graphs/getVertices``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getVertices -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getVertices -H 'Content-Type: Application/json' -d '
    [
      {"serviceName": "s2graph", "columnName": "user_id", "ids": [1, 2, 3]}
    ]'

--- a/doc/source/api/mutate/mutate_edge.rst
+++ b/doc/source/api/mutate/mutate_edge.rst
@@ -46,9 +46,9 @@ Then insert a same set of edges to each labels and query them as follows.
 
 **strong consistency**
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhosnt:9000/graphs/edges/insert -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/edges/insert -H 'Content-Type: Application/json' -d '
   [
     {"timestamp": 1, "from": 101, "to": 10, "label": "s2graph_label_test", "props": {"time": 0}},
     {"timestamp": 2, "from": 101, "to": 10, "label": "s2graph_label_test", "props": {"time": -10}},
@@ -94,9 +94,9 @@ Note that only one edge exist between (101, 10, s2graph_label_test, out).
 
 **weak consistency**
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/edges/insert -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/edges/insert -H 'Content-Type: Application/json' -d '
    [
      {"timestamp": 1, "from": 101, "to": 10, "label": "s2graph_label_test_weak", "props": {"time": 0}},
      {"timestamp": 2, "from": 101, "to": 10, "label": "s2graph_label_test_weak", "props": {"time": -10}},
@@ -188,9 +188,9 @@ Delete - ``POST /mutate/edge/delete``
 
 For edge deletion, again, S2Graph looks for a unique edge with (from, to, label, direction). However, this time it checks the timestamp of the delete request and the existing edge. The timestamp on the delete request ``must be larger than that on the existing edge`` or else the request will be ignored. If everything is well, the edge will be deleted. Also note that no props information is necessary for a delete request on a strongly consistent label since there will be only one edge with edge`s unique id(from, to, label, direction).
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/delete -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/delete -H 'Content-Type: Application/json' -d '
    [
      {"timestamp": 10, "from": 101, "to": 10, "label": "s2graph_label_test"}
    ]'
@@ -201,9 +201,9 @@ Update - ``POST /mutate/edge/update``
 What an update operation does to a strongly consistent label is identical to an insert.
 
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/update -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/update -H 'Content-Type: Application/json' -d '
    [
      {"timestamp": 10, "from": 101, "to": 10, "label": "s2graph_label_test", "props": {"time": 100, "weight": -10}}
    ]'
@@ -214,9 +214,9 @@ Increment - ``POST /mutate/edge/increment``
 
 Works like update, other than it returns the incremented value and not the old value.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/increment -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/increment -H 'Content-Type: Application/json' -d '
    [
      {"timestamp": 10, "from": 101, "to": 10, "label": "s2graph_label_test", "props": {"time": 100, "weight": -10}}
    ]'
@@ -226,9 +226,9 @@ Delete All - ``POST /mutate/edge/deleteAll``
 
 Delete all adjacent edges to the source vertex. ``Please note that edges with both in and out directions will be deleted``
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/deleteAll -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/deleteAll -H 'Content-Type: Application/json' -d '
    [
      {"ids" : [101], "label":"s2graph_label_test", "direction": "out", "timestamp":1417616441000}
    ]'
@@ -248,9 +248,9 @@ Delete - ``POST /graphs/edges/delete``
 
 For deletion on weakly consistent edges, first, S2Graph fetches existing edges from storage. Then, on each resulting edges, fires the actual delete operations.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/edges/delete -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/edges/delete -H 'Content-Type: Application/json' -d '
    [
      {
        "cacheRemain": -148,
@@ -320,9 +320,9 @@ Delete All - ``POST /mutate/edge/deleteAll``
 
 Identical to strong consistency.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/deleteAll -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/deleteAll -H 'Content-Type: Application/json' -d '
    [
      {"ids" : [101], "label":"s2graph_label_test", "direction": "out", "timestamp":1417616441}
    ]'

--- a/doc/source/api/query/query_edge.rst
+++ b/doc/source/api/query/query_edge.rst
@@ -22,9 +22,9 @@ return edge for given vertex pair only if edge exist.
 This is more ``general`` way to check edge existence between any given vertex pairs comparing using ``_to`` on query parameter
 
 
-.. code:: bashn
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/checkEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/checkEdges -H 'Content-Type: Application/json' -d '
    [
      {"label": "talk_friend", "direction": "out", "from": 1, "to": 100},
      {"label": "talk_friend", "direction": "out", "from": 1, "to": 101}
@@ -40,9 +40,9 @@ Select edges with query.
 
 Here is a very basic query to fetch all edges that start from source vertex "101".
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
 
        "srcVertices": [
@@ -404,7 +404,7 @@ You can also run two queries concurrently, and filter the result of one query wi
 S2Graph will run two concurrent queries, one in the main step, and another in the filter out clause. Here is more practical example.
 
 
-.. coce:: bash
+.. code:: bash
 
    {
      "filterOut": {
@@ -657,9 +657,9 @@ S2Graph provides step-level aggregation so that users can take the top K items f
 
 **sample Example**
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
      "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
      "steps": [
@@ -863,10 +863,10 @@ Add more steps for wider traversals. Be gentle on the limit options since the nu
 
 Example 1. From label "graph_test", select the first 100 edges that start from vertex "account_id = 1", with default sorting.
 
-.. code:: bash
+.. parsed-literal::
 
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -877,9 +877,9 @@ Example 1. From label "graph_test", select the first 100 edges that start from v
 
 Example 2. Now select between the 50th and 100th edges from the same query.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -889,9 +889,9 @@ Example 2. Now select between the 50th and 100th edges from the same query.
 
 Example 3. Now add a time range filter so that you will only get the edges that were inserted between 1416214118000 and 1416300000000.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -901,9 +901,9 @@ Example 3. Now add a time range filter so that you will only get the edges that 
 
 Example 4. Now add scoring rule to sort the result by indexed properties "time" and "weight", with weights of 1.5 and 10, respectively.
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -914,9 +914,9 @@ Example 4. Now add scoring rule to sort the result by indexed properties "time" 
 
 Example 5. Make a two-step query to fetch friends of friends of a user "account_id = 1". (Limit the first step by 10 friends and the second step by 100.)
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -928,9 +928,9 @@ Example 5. Make a two-step query to fetch friends of friends of a user "account_
 
 Example 6. Make a two-step query to fetch the music playlist of the friends of user "account_id = 1". Limit the first step by 10 friends and the second step by 100 tracks.)
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [
@@ -942,9 +942,9 @@ Example 6. Make a two-step query to fetch the music playlist of the friends of u
 
 Example 7. Query the friends of user "account_id = 1" who played the track "track_id = 200".
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
    {
        "srcVertices": [{"serviceName": "s2graph", "columnName": "account_id", "id":1}],
        "steps": [

--- a/doc/source/api/query/query_vertex.rst
+++ b/doc/source/api/query/query_vertex.rst
@@ -8,9 +8,9 @@ POST - ``/graphs/getVertices``
 
 Selecting all vertices from serviceColumn account_id of a service s2graph.
 
-.. code:: bash
+.. parsed-literal::
 
-    curl -XPOST localhost:9000/graphs/getVertices -H 'Content-Type: Application/json' -d '
+    curl -XPOST |example_base_url|/graphs/getVertices -H 'Content-Type: Application/json' -d '
     [
         {"serviceName": "s2graph", "columnName": "account_id", "ids": [1, 2, 3]},
         {"serviceName": "agit", "columnName": "user_id", "ids": [1, 2, 3]}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -186,3 +186,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+# -- Project specific configuration ------------------------------------------
+example_base_url_value = 'localhost:8000'
+rst_epilog = '.. |example_base_url| replace:: %s' % example_base_url_value

--- a/doc/source/getting_started/your_first_graph.rst
+++ b/doc/source/getting_started/your_first_graph.rst
@@ -9,9 +9,9 @@ First, we need a name for the new service.
 
 The following POST query will create a service named ``KakaoFavorites``
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/admin/createService -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/admin/createService -H 'Content-Type: Application/json' -d '
   {
     "serviceName": "KakaoFavorites",
     "compressionAlgorithm" : "gz"
@@ -19,17 +19,17 @@ The following POST query will create a service named ``KakaoFavorites``
 
 To make sure the service is created correctly, check out the following
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XGET localhost:9000/admin/getService/KakaoFavorites
+  curl -XGET |example_base_url|/admin/getService/KakaoFavorites
 
 Next, we will need some friends.
 ---------------------------------------------
 In S2Graph, relationships are organized as labels. Create a ``friends`` label with the following ``createLabel`` API call:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/admin/createLabel -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/admin/createLabel -H 'Content-Type: Application/json' -d '
   {
     "label": "friends",
     "srcServiceName": "KakaoFavorites",
@@ -46,15 +46,15 @@ In S2Graph, relationships are organized as labels. Create a ``friends`` label wi
 
 Check if the label has been created correctly:
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XGET localhost:9000/admin/getLabel/friends
+   curl -XGET |example_base_url|/admin/getLabel/friends
 
 Now that the label ``friends`` is ready, we can store the friendship data. Entries of a label are called edges, and you can add edges with ``edges/insert`` API:
 
-.. code:: bash
+.. parsed-literal::
 
-   curl -XPOST localhost:9000/mutate/edge/insert -H 'Content-Type: Application/json' -d '
+   curl -XPOST |example_base_url|/mutate/edge/insert -H 'Content-Type: Application/json' -d '
    [
       {"from":"Elmo","to":"Big Bird","label":"friends","props":{},"timestamp":1444360152477},
       {"from":"Elmo","to":"Ernie","label":"friends","props":{},"timestamp":1444360152478},
@@ -66,9 +66,9 @@ Now that the label ``friends`` is ready, we can store the friendship data. Entri
 
 Query friends of Elmo with ``getEdges`` API:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
   {
     "srcVertices": [{"serviceName": "KakaoFavorites", "columnName": "userName", "id":"Elmo"}],
     "steps": [
@@ -78,9 +78,9 @@ Query friends of Elmo with ``getEdges`` API:
 
 Now query friends of Cookie Monster:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
   {
     "srcVertices": [{"serviceName": "KakaoFavorites", "columnName": "userName", "id":"Cookie Monster"}],
     "steps": [
@@ -93,9 +93,9 @@ Users of Kakao Favorites will be able to ``post`` URLs of their favorite website
 
 We will need a new label ``post`` for this data:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/admin/createLabel -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/admin/createLabel -H 'Content-Type: Application/json' -d '
   {
     "label": "post",
     "srcServiceName": "KakaoFavorites",
@@ -112,9 +112,9 @@ We will need a new label ``post`` for this data:
 
 Now, insert some posts of the users:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/mutate/edge/insert -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/mutate/edge/insert -H 'Content-Type: Application/json' -d '
   [
     {"from":"Big Bird","to":"www.kakaocorp.com/en/main","label":"post","props":{},"timestamp":1444360152477},
     {"from":"Big Bird","to":"github.com/kakao/s2graph","label":"post","props":{},"timestamp":1444360152478},
@@ -127,9 +127,9 @@ Now, insert some posts of the users:
 
 Query posts of Big Bird:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
   {
     "srcVertices": [{"serviceName": "KakaoFavorites", "columnName": "userName", "id":"Big Bird"}],
     "steps": [
@@ -144,9 +144,9 @@ So far, we have designed a label schema for the labels ``friends`` and ``post``,
 This should be enough for creating the timeline feature! The following two-step query will return the URLs for Elmo's timeline, which are the posts of Elmo's friends:
 
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
   {
     "srcVertices": [{"serviceName": "KakaoFavorites", "columnName": "userName", "id":"Elmo"}],
     "steps": [
@@ -157,9 +157,9 @@ This should be enough for creating the timeline feature! The following two-step 
 
 Also try Cookie Monster's timeline:
 
-.. code:: bash
+.. parsed-literal::
 
-  curl -XPOST localhost:9000/graphs/getEdges -H 'Content-Type: Application/json' -d '
+  curl -XPOST |example_base_url|/graphs/getEdges -H 'Content-Type: Application/json' -d '
   {
     "srcVertices": [{"serviceName": "KakaoFavorites", "columnName": "userName", "id":"Cookie Monster"}],
     "steps": [
@@ -170,9 +170,3 @@ Also try Cookie Monster's timeline:
 
 
 The example above is by no means a full blown social network timeline, but it gives you an idea of how to represent, store and query graph data with S2Graph.
-
-We also provide a simple script under ``script/test.sh`` so that you can see if everything is setup correctly.
-
-.. code:: bash
-
-  sh script/test.sh

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,6 @@ dev@s2graph.incubator.apache.org is for people who want to contribute to S2Graph
 
    getting_started/index
    getting_started/your_first_graph
-   design/data_model
    api/index
 
 ..


### PR DESCRIPTION
I've added a configuration for curl example base url and let each rst source refer to the variable for interpolation.
As the variable is used in code block, I also had to replace `.. code:: bash` with `.. parsed-literal::`. `curl` command examples actually do not get much benefit from `.. code:: bash`, so I think `.. parsed-literal::` is good enough for the purpose.
And, I removed the sentence mentioning `script/test.sh` and `design/data_model` page reference because they don't exist and make logs errors.
Please review the changes and merge it if okay.
Thanks!